### PR TITLE
added spec version comparator

### DIFF
--- a/lib/unwrappr.rb
+++ b/lib/unwrappr.rb
@@ -1,6 +1,7 @@
 require 'unwrappr/version'
 require 'unwrappr/cli'
+require 'unwrappr/spec_version_comparator'
 
 module Unwrappr
-  
+
 end

--- a/lib/unwrappr/spec_version_comparator.rb
+++ b/lib/unwrappr/spec_version_comparator.rb
@@ -1,0 +1,29 @@
+module Unwrappr
+  class SpecVersionComparator
+    # specs are arrays of specs like 'name (version)'
+    def self.perform(specs_before, specs_after)
+      index_before = build_spec_index(specs_before)
+      index_after = build_spec_index(specs_after)
+
+      (index_before.keys + index_after.keys).uniq.sort.map do |key|
+        {
+          dependency: key,
+          before: index_before[key],
+          after: index_after[key],
+        }
+      end
+    end
+
+    def self.build_spec_index(specs)
+      Hash[specs.map { |item| parse_spec(item) }]
+    end
+
+    def self.parse_spec(spec)
+      md = spec.match /^([^\s]+)\s\(([^\s]+)\)$/
+      raise ArgumentError, spec if md.nil?
+      [md[1], md[2]]
+    end
+
+    private_class_method :build_spec_index, :parse_spec
+  end
+end

--- a/spec/lib/spec_version_comparator_spec.rb
+++ b/spec/lib/spec_version_comparator_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+RSpec.describe Unwrappr::SpecVersionComparator do
+  subject(:perform) { described_class.perform(specs_before, specs_after) }
+  let(:specs_before) { [] }
+  let(:specs_after) { [] }
+
+  context 'empty specs lists' do
+    it 'returns empty change set' do
+      expect(subject).to be_empty
+    end
+  end
+
+  context 'version upgrade' do
+    let(:specs_before) { ['cloudinary (1.9.1)'] }
+    let(:specs_after) { ['cloudinary (1.10.0)'] }
+    it 'returns versions' do
+      expect(subject).to eq([{ dependency: 'cloudinary', before: '1.9.1', after: '1.10.0' }])
+    end
+  end
+
+  context 'added dependency' do
+    let(:specs_before) { [] }
+    let(:specs_after) { ['cloudinary (1.10.0)'] }
+    it 'returns versions' do
+      expect(subject).to eq([{ dependency: 'cloudinary', before: nil, after: '1.10.0' }])
+    end
+  end
+
+  context 'removed dependency' do
+    let(:specs_before) { ['cloudinary (1.9.1)'] }
+    let(:specs_after) { [] }
+    it 'returns versions' do
+      expect(subject).to eq([{ dependency: 'cloudinary', before: '1.9.1', after: nil }])
+    end
+  end
+
+  context 'multiple dependencies' do
+    let(:specs_before) { ['cloudinary (1.9.1)', 'apiary (2.3.1)'] }
+    let(:specs_after) { ['cloudinary (1.9.1)', 'apiary (3.1.1)'] }
+
+    it 'returns all dependencies' do
+      expect(subject.size).to eq 2
+    end
+  end
+end


### PR DESCRIPTION
We need to parse lock file and compare spec versions. Another helper  (e.g. LockFileParser) should find `GEM` section and parse its top-level specs:
```
PATH
  remote: engines/an_engine
  specs:
    an_engine (0.0.1)
      pg (= 0.21.0)
      rails (~> 4.2.7.1)

GEM
  remote: https://rubygems.org/
  remote: https://rubygems.envato.com/
  specs:
    actionmailer (4.2.7.1)
      actionpack (= 4.2.7.1)
...
```

SpecVersionComparator expect parsed spec line as an input, e.g.

```ruby
[
    'actionpack (4.2.7.1)',
    'actionview (4.2.7.1)',
    'active_model_serializers (0.10.7)',
]
```

```Ruby
Unwrappr::SpecVersionComparator.perform(specs_before, specs_after)
```

and results could be
```ruby
[
  {:dependency=>"actionpack", :before=>"4.2.7.1", :after=>"4.2.7.1"},
  {:dependency=>"actionview", :before=>"4.2.7.1", :after=>"4.2.7.1"}, 
  {:dependency=>"active_model_serializers", :before=>"0.10.7", :after=>"0.10.7"}
]
```