### PR TITLE
Annotate Github Pull Requests via CLI

### DIFF
--- a/lib/unwrappr/cli.rb
+++ b/lib/unwrappr/cli.rb
@@ -22,5 +22,24 @@ module Unwrappr
         GitCommandRunner.make_pull_request!
       end
     end
+
+    subcommand 'annotate-pull-request',
+               'Annotate Gemfile.lock changes in a Github pull request' do
+
+      option '--repo', 'REPO',
+             'The repo in github <owner/project>',
+             required: true
+
+      option '--pr', 'PR',
+             'The github PR number',
+             required: true
+
+      def execute
+        LockFileAnnotator.annotate_github_pull_request(
+          repo: repo,
+          pr_number: pr.to_i
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
Add a command line option to annotate a Github pull request. This means we can easily annotate the next Marketplace bundle update PR from the comfort of our local command line:

```
 GITHUB_TOKEN=xxxxxx
bundle exec unwrappr annotate-pull-request --repo 'envato/marketplace' --pr 22462
```