### PR TITLE
Refactor git_command_runner_spec

### DIFF
--- a/lib/unwrappr/git_command_runner.rb
+++ b/lib/unwrappr/git_command_runner.rb
@@ -28,6 +28,7 @@ module Unwrappr
       def reset_client
         @git_client = nil
         @git = nil
+        @github_token = nil
       end
 
       def show(revision, path)

--- a/spec/lib/unwrappr/git_command_runner_spec.rb
+++ b/spec/lib/unwrappr/git_command_runner_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 RSpec.describe Unwrappr::GitCommandRunner do
-  let!(:fake_git) { instance_double(Git::Base) }
+  let(:fake_git) { instance_double(Git::Base, :fake_git) }
 
   before do
     described_class.reset_client
@@ -11,101 +11,101 @@ RSpec.describe Unwrappr::GitCommandRunner do
   end
 
   describe '#create_branch!' do
+    subject(:create_branch!) { described_class.create_branch! }
+
+    before { allow(Time).to receive(:now).and_return(Time.parse('2017-01-01 11:23')) }
+
     context 'Given current directory is not a git repo' do
       before do
         expect(fake_git).to receive(:current_branch).and_raise(Git::GitExecuteError)
       end
 
-      it 'raises' do
-        expect { Unwrappr::GitCommandRunner.create_branch! }
-          .to raise_error 'Not a git working dir'
+      specify do
+        expect { create_branch! }.to raise_error(RuntimeError, 'Not a git working dir')
       end
     end
 
     context 'Given the current directory is a git repo' do
-      let(:result) { double('Branch', checkout: true) }
       before do
-        allow(Time).to receive(:now).and_return(Time.parse('2017-01-01 11:23'))
         expect(fake_git).to receive(:current_branch).and_return('master')
         expect(fake_git).to receive(:checkout).with('origin/master')
       end
 
-      it 'does not raise' do
-        expect(fake_git).to receive(:branch)
-          .with('auto_bundle_update_20170101-1123')
-          .and_return(result)
-        expect { Unwrappr::GitCommandRunner.create_branch! }.not_to raise_error
+      it 'checks out a new branch based on origin/master, with a timestamp' do
+        expect(fake_git).to receive(:branch).with('auto_bundle_update_20170101-1123').and_return(fake_git)
+
+        expect(fake_git).to receive(:checkout).with(no_args)
+
+        expect(create_branch!).to be_nil
       end
 
-      context 'When there is some failiure in creating the branch' do
-        it 'raises' do
+      context 'When there is some failure in creating the branch' do
+        before do
           expect(fake_git).to receive(:branch)
             .with('auto_bundle_update_20170101-1123')
             .and_raise(Git::GitExecuteError)
-          expect { Unwrappr::GitCommandRunner.create_branch! }
-            .to raise_error 'failed to create branch'
+        end
+
+        specify do
+          expect { create_branch! }.to raise_error(RuntimeError, 'failed to create branch')
         end
       end
     end
   end
 
-  describe '#commit_and_push_changes' do
-    before do
-      allow(fake_git).to receive(:current_branch).and_return('some-new-branch')
-    end
+  describe '#commit_and_push_changes!' do
+    subject(:commit_and_push_changes!) { described_class.commit_and_push_changes! }
 
     context 'Given the git add command fails' do
       before do
-        expect(fake_git).to receive(:add).and_raise(Git::GitExecuteError)
+        expect(fake_git).to receive(:add).with(all: true).and_raise(Git::GitExecuteError)
       end
 
-      it 'raises' do
-        expect { Unwrappr::GitCommandRunner.commit_and_push_changes! }
-          .to raise_error 'failed to add git changes'
+      specify do
+        expect { commit_and_push_changes! }
+          .to raise_error RuntimeError, 'failed to add git changes'
       end
     end
 
     context 'Given the git add command is successful' do
       before do
-        expect(fake_git).to receive(:add).and_return(true)
+        expect(fake_git).to receive(:add).with(all: true).and_return(true)
       end
 
       context 'When the git commit command fails' do
         before do
-          expect(fake_git).to receive(:commit).and_raise(Git::GitExecuteError)
+          expect(fake_git).to receive(:commit).with('Automatic Bundle Update').and_raise(Git::GitExecuteError)
         end
 
-        it 'raises' do
-          expect { Unwrappr::GitCommandRunner.commit_and_push_changes! }
-            .to raise_error 'failed to commit changes'
+        specify do
+          expect { commit_and_push_changes! }.to raise_error(RuntimeError, 'failed to commit changes')
         end
       end
 
       context 'Given the git commit command is successful' do
         before do
-          expect(fake_git).to receive(:commit).and_return(true)
+          expect(fake_git).to receive(:commit).with('Automatic Bundle Update').and_return(true)
         end
 
         context 'Given the git push command fails' do
           before do
-            expect(fake_git).to receive(:push).and_raise(Git::GitExecuteError)
+            expect(fake_git).to receive(:current_branch).and_return('branchname')
+            expect(fake_git).to receive(:push).with('origin', 'branchname').and_raise(Git::GitExecuteError)
           end
 
-          it 'raises' do
-            expect { Unwrappr::GitCommandRunner.commit_and_push_changes! }
-              .to raise_error 'failed to push changes'
+          specify do
+            expect { commit_and_push_changes! }
+              .to raise_error(RuntimeError, 'failed to push changes')
           end
         end
 
         context 'Given the git push command is successful' do
           before do
-            expect(fake_git).to receive(:push).and_return(true)
+            expect(fake_git).to receive(:current_branch).and_return('branchname')
+            expect(fake_git).to receive(:push).with('origin', 'branchname').and_return(true)
           end
 
-          it 'does not raise' do
-            expect { Unwrappr::GitCommandRunner.commit_and_push_changes! }
-              .not_to raise_error
-          end
+          it { is_expected.to be_nil }
         end
       end
     end
@@ -113,107 +113,103 @@ RSpec.describe Unwrappr::GitCommandRunner do
 
   describe '#make_pull_request!' do
     subject(:make_pull_request!) { Unwrappr::GitCommandRunner.make_pull_request! }
-    let(:github_response) { double('response', number: 34) }
-    let(:octokit_client) { instance_spy(Octokit::Client) }
-    let(:git_url) { 'https://github.com/org/repo' }
+
+    let(:git_url) { 'https://github.com/org/repo.git' }
+    let(:octokit_client) { instance_spy(Octokit::Client, :fake_octokit, pull_request_files: []) }
 
     before do
-      allow(ENV).to receive(:fetch).with('GITHUB_TOKEN').and_return('fake tokenz r us')
-      allow(Octokit::Client).to receive(:new).and_return octokit_client
       allow(fake_git).to receive(:config).with('remote.origin.url').and_return(git_url)
       allow(fake_git).to receive(:current_branch).and_return('some-new-branch')
-      allow(fake_git).to receive(:show).and_return('some text')
-      allow(Unwrappr::LockFileAnnotator).to receive(:annotate_github_pull_request)
+
+      allow(Octokit::Client).to receive(:new).and_return octokit_client
     end
 
-    context 'Given a successful octokit pull request is created' do
+    context 'with a token' do
       before do
-        allow(octokit_client).to receive(:create_pull_request).and_return(github_response)
+        allow(ENV).to receive(:fetch).with('GITHUB_TOKEN').and_return('fake tokenz r us')
       end
 
-      context 'When Git URL ends with .git' do
-        let(:git_url) { 'git@github.com:org/repo.git' }
-
-        it 'creates a pull request in the repo' do
-          make_pull_request!
-          expect(octokit_client).to have_received(:create_pull_request).with(
+      context 'Given a successful Octokit pull request is created' do
+        before do
+          expect(octokit_client).to receive(:create_pull_request).with(
             'org/repo',
             any_args
-          )
+          ).and_return(response)
         end
 
-        it 'annotates the pull request' do
-          make_pull_request!
-          expect(Unwrappr::LockFileAnnotator)
-            .to have_received(:annotate_github_pull_request)
-            .with(repo: 'org/repo', pr_number: 34, client: octokit_client)
+        let(:agent) { Sawyer::Agent.new('http://foo.com/a/') }
+        let(:response) { Sawyer::Resource.new(agent, number: 34) }
+
+        context 'When Git URL ends with .git' do
+          let(:git_url) { 'git@github.com:org/repo.git' }
+
+          it 'annotates the pull request' do
+            allow(Unwrappr::LockFileAnnotator).to receive(:annotate_github_pull_request)
+
+            make_pull_request!
+
+            expect(Unwrappr::LockFileAnnotator)
+              .to have_received(:annotate_github_pull_request)
+              .with(repo: 'org/repo', pr_number: 34, client: octokit_client)
+          end
         end
 
-        it 'does not raise any error' do
-          expect { make_pull_request! }
-            .not_to raise_error
+        context 'When Git URL does not end with .git' do
+          let(:git_url) { 'https://github.com/org/repo' }
+
+          it 'annotates the pull request' do
+            allow(Unwrappr::LockFileAnnotator).to receive(:annotate_github_pull_request)
+
+            make_pull_request!
+
+            expect(Unwrappr::LockFileAnnotator)
+              .to have_received(:annotate_github_pull_request)
+              .with(repo: 'org/repo', pr_number: 34, client: octokit_client)
+          end
         end
       end
 
-      context 'When Git URL does not end with .git' do
-        let(:git_url) { 'https://github.com/org/repo' }
-
-        it 'creates a pull request in the repo' do
-          make_pull_request!
-          expect(octokit_client).to have_received(:create_pull_request).with(
-            'org/repo',
-            any_args
-          )
+      context 'Given an exception is raised from octokit' do
+        before do
+          expect(octokit_client).to receive(:create_pull_request)
+            .and_raise(Octokit::ClientError)
         end
 
-        it 'annotates the pull request' do
-          make_pull_request!
-          expect(Unwrappr::LockFileAnnotator)
-            .to have_received(:annotate_github_pull_request)
-            .with(repo: 'org/repo', pr_number: 34, client: octokit_client)
-        end
-
-        it 'does not raise any error' do
+        specify do
           expect { make_pull_request! }
-            .not_to raise_error
+            .to raise_error(RuntimeError, 'failed to create and annotate pull request')
         end
       end
     end
 
-    context 'Given an exception is raised from octokit' do
-      it 'raises' do
-        expect(octokit_client).to receive(:create_pull_request)
-          .and_raise Octokit::ClientError
+    context 'without a token' do
+      before do
+        allow(ENV).to receive(:[]).with('GITHUB_TOKEN').and_return(nil)
+      end
 
-        expect { Unwrappr::GitCommandRunner.make_pull_request! }
-          .to raise_error 'failed to create and annotate pull request'
+      it 'provides useful feedback' do
+        expect { make_pull_request! }.to raise_error(RuntimeError, /^Missing environment variable/)
       end
     end
   end
 
   describe '#show' do
-    subject(:show) { Unwrappr::GitCommandRunner.show('HEAD', 'Gemfile.lock') }
+    subject(:show) { described_class.show('HEAD', 'Gemfile.lock') }
 
-    before do
-      allow(fake_git).to receive(:show)
+    context 'when the proxied git command succeeds' do
+      before do
+        expect(fake_git).to receive(:show).with('HEAD', 'Gemfile.lock').and_return('content')
+      end
+
+      it { is_expected.to eq('content') }
     end
 
-    it 'calls git.show using proper parameters' do
-      expect(fake_git).to receive(:show).with('HEAD', 'Gemfile.lock')
+    context 'when the proxied git command fails' do
+      before do
+        expect(fake_git).to receive(:show).and_raise(Git::GitExecuteError)
+      end
 
-      show
-    end
-
-    it 'returns the result' do
-      allow(fake_git).to receive(:show).and_return('content')
-
-      expect(show).to eq('content')
-    end
-
-    it 'handles client exceptions' do
-      allow(fake_git).to receive(:show).and_raise(Git::GitExecuteError)
-
-      expect(show).to be_nil
+      it { is_expected.to be_nil }
     end
   end
 end


### PR DESCRIPTION
#### Context

When I was working on https://github.com/envato/unwrappr/pull/34 , I found some
of the rspec output vague. 'it does not raise' doesn't tell me what "it" _is_
expected to do. Which reminded me of https://stackoverflow.com/a/6181656/78845

I also struggled to add a spec for my change at the time because one of the
stubbed objects (the response, I think) wasn't behaving as a real one might.

#### Change

###### Before

```
Unwrappr::GitCommandRunner
  #create_branch!
    Given current directory is not a git repo
      raises
    Given the current directory is a git repo
      does not raise
      When there is some failiure in creating the branch
        raises
  #commit_and_push_changes
    Given the git add command fails
      raises
    Given the git add command is successful
      When the git commit command fails
        raises
      Given the git commit command is successful
        Given the git push command fails
          raises
        Given the git push command is successful
          does not raise
  #make_pull_request!
    Given a successful octokit pull request is created
      When Git URL ends with .git
        creates a pull request in the repo
        annotates the pull request
        does not raise any error
      When Git URL does not end with .git
        creates a pull request in the repo
        annotates the pull request
        does not raise any error
    Given an exception is raised from octokit
      raises
  #show
    calls git.show using proper parameters
    returns the result
    handles client exceptions

Finished in 0.06376 seconds (files took 0.95193 seconds to load)
17 examples, 0 failures
```

#### After:

```
Unwrappr::GitCommandRunner
  #create_branch!
    Given current directory is not a git repo
      should raise RuntimeError with "Not a git working dir"
    Given the current directory is a git repo
      checks out a new branch based on origin/master, with a timestamp
      When there is some failure in creating the branch
        should raise RuntimeError with "failed to create branch"
  #commit_and_push_changes!
    Given the git add command fails
      should raise RuntimeError with "failed to add git changes"
    Given the git add command is successful
      When the git commit command fails
        should raise RuntimeError with "failed to commit changes"
      Given the git commit command is successful
        Given the git push command fails
          should raise RuntimeError with "failed to push changes"
        Given the git push command is successful
          should be nil
  #make_pull_request!
    with a token
      Given a successful Octokit pull request is created
        When Git URL ends with .git
          annotates the pull request
        When Git URL does not end with .git
          annotates the pull request
      Given an exception is raised from octokit
        should raise RuntimeError with "failed to create and annotate pull request"
    without a token
      provides useful feedback
  #show
    when the proxied git command succeeds
      should eq "content"
    when the proxied git command fails
      should be nil

Finished in 0.08103 seconds (files took 1.19 seconds to load)
13 examples, 0 failures
```

#### Considerations

I'm not particularly tied to any of these changes, it was just a fun exercise on my day off :-)