### PR TITLE
Fill this bit out

### DIFF
--- a/unwrappr.gemspec
+++ b/unwrappr.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength:
   spec.email = AUTHORS.keys
 
   spec.summary = "A tool to unwrap your gems and see what's changed easily"
-  spec.description = "bundle update PRs: Automated. Annotated."
+  spec.description = 'bundle update PRs: Automated. Annotated.'
   spec.homepage = 'http://www.unwrappr.com.org'
   spec.license = 'MIT'
 

--- a/unwrappr.gemspec
+++ b/unwrappr.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength:
   spec.email = AUTHORS.keys
 
   spec.summary = "A tool to unwrap your gems and see what's changed easily"
-  spec.description = "Let's fill this bit out later"
+  spec.description = "bundle update PRs: Automated. Annotated."
   spec.homepage = 'http://www.unwrappr.com.org'
   spec.license = 'MIT'
 


### PR DESCRIPTION
#### Context

I just published `unwrappr` to RubyGems. And then spotted this:
![unwrappr rubygems org your community gem host 2018-11-12 19-57-27](https://user-images.githubusercontent.com/39911/48336802-4c65a900-e6b5-11e8-8923-e34e8d371267.png)

#### Change 

 - Add description

#### Cc

@orien, @joesustaric 