### PR TITLE
Specify Ruby and RubyGems requirements in gemspec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,8 +1,11 @@
 ---
 AllCops:
-  TargetRubyVersion: 2.5.1
+  TargetRubyVersion: 2.5
   Exclude:
     - 'spike/*.rb'
+
+Gemspec/RequiredRubyVersion:
+  Enabled: false
 
 Metrics/BlockLength:
   Exclude:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+ - Specify Ruby and RubyGems requirements in gemspec.
 
 ## [0.3.1] 2018-11-12
 ### Changed

--- a/lib/unwrappr/gem_version.rb
+++ b/lib/unwrappr/gem_version.rb
@@ -45,13 +45,6 @@ module Unwrappr
     def segment(index)
       segment = @version.canonical_segments[index] || 0
       (segment.is_a?(Numeric) ? segment : nil)
-    rescue NoMethodError
-      abort(<<~MESSAGE)
-        Unwrappr requires RubyGems v2.7.0 or newer.
-
-        To upgrade to the latest RubyGems visit https://rubygems.org/pages/download
-
-      MESSAGE
     end
   end
 end

--- a/unwrappr.gemspec
+++ b/unwrappr.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength:
   spec.homepage = 'http://www.unwrappr.com.org'
   spec.license = 'MIT'
   spec.required_ruby_version = '~> 2.3'
+  spec.required_rubygems_version = '~> 2.7'
 
   spec.files = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})

--- a/unwrappr.gemspec
+++ b/unwrappr.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength:
   spec.description = 'bundle update PRs: Automated. Annotated.'
   spec.homepage = 'http://www.unwrappr.com.org'
   spec.license = 'MIT'
+  spec.required_ruby_version = '~> 2.3'
 
   spec.files = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})


### PR DESCRIPTION
#### Context

After publishing the gem and watching the downloads increase, I spotted this.

<img width="1280" alt="unwrappr rubygems org your community gem host 2018-11-13 09-17-49" src="https://user-images.githubusercontent.com/39911/48378541-0fd19600-e725-11e8-95b6-42f56555f839.png">

We know that unwrappr doesn't work with Ruby 2.2 or RubyGems < 2.7.0

#### Change

Implemented the specifications as documented here: https://guides.rubygems.org/specification-reference/#required_ruby_version , which allowed me to retire a check in the code. I then had to stop Rubocop failing the build for a preference that we'll not meet.
