### PR TITLE
Optimisation: Don't call Github comparison API when adding or removing a gem

### DIFF
--- a/lib/unwrappr/researchers/github_comparison.rb
+++ b/lib/unwrappr/researchers/github_comparison.rb
@@ -12,14 +12,13 @@ module Unwrappr
         @client = client
       end
 
-      def research(gem_change, gem_change_info)
-        repo = gem_change_info[:github_repo]
-        return gem_change_info if repo.nil? ||
-                                  gem_change.base_version.nil? ||
-                                  gem_change.head_version.nil?
+      def research(gem_change, change_info)
+        return change_info if github_repo_not_identified?(change_info) ||
+                              gem_change.base_version.nil? ||
+                              gem_change.head_version.nil?
 
-        gem_change_info.merge(
-          github_comparison: try_comparing(repo: repo,
+        change_info.merge(
+          github_comparison: try_comparing(repo: github_repo(change_info),
                                            base: gem_change.base_version,
                                            head: gem_change.head_version)
         )
@@ -37,6 +36,14 @@ module Unwrappr
         @client.compare(repo, base, head)
       rescue Octokit::NotFound
         nil
+      end
+
+      def github_repo_not_identified?(gem_change_info)
+        github_repo(gem_change_info).nil?
+      end
+
+      def github_repo(gem_change_info)
+        gem_change_info[:github_repo]
       end
     end
   end

--- a/lib/unwrappr/researchers/github_comparison.rb
+++ b/lib/unwrappr/researchers/github_comparison.rb
@@ -14,8 +14,7 @@ module Unwrappr
 
       def research(gem_change, change_info)
         return change_info if github_repo_not_identified?(change_info) ||
-                              gem_change.base_version.nil? ||
-                              gem_change.head_version.nil?
+                              gem_added_or_removed?(gem_change)
 
         change_info.merge(
           github_comparison: try_comparing(repo: github_repo(change_info),
@@ -44,6 +43,10 @@ module Unwrappr
 
       def github_repo(gem_change_info)
         gem_change_info[:github_repo]
+      end
+
+      def gem_added_or_removed?(gem_change)
+        gem_change.base_version.nil? || gem_change.head_version.nil?
       end
     end
   end

--- a/lib/unwrappr/researchers/github_comparison.rb
+++ b/lib/unwrappr/researchers/github_comparison.rb
@@ -17,9 +17,11 @@ module Unwrappr
                               gem_added_or_removed?(gem_change)
 
         change_info.merge(
-          github_comparison: try_comparing(repo: github_repo(change_info),
-                                           base: gem_change.base_version,
-                                           head: gem_change.head_version)
+          github_comparison: try_comparing(
+            repo: github_repo(change_info),
+            base: gem_change.base_version,
+            head: gem_change.head_version
+          )
         )
       end
 

--- a/lib/unwrappr/researchers/github_comparison.rb
+++ b/lib/unwrappr/researchers/github_comparison.rb
@@ -14,14 +14,14 @@ module Unwrappr
 
       def research(gem_change, gem_change_info)
         repo = gem_change_info[:github_repo]
-        return gem_change_info if repo.nil?
+        return gem_change_info if repo.nil? ||
+                                  gem_change.base_version.nil? ||
+                                  gem_change.head_version.nil?
 
         gem_change_info.merge(
-          github_comparison: try_comparing(
-            repo: repo,
-            base: gem_change.base_version,
-            head: gem_change.head_version
-          )
+          github_comparison: try_comparing(repo: repo,
+                                           base: gem_change.base_version,
+                                           head: gem_change.head_version)
         )
       end
 

--- a/spec/lib/unwrappr/researchers/github_comparison_spec.rb
+++ b/spec/lib/unwrappr/researchers/github_comparison_spec.rb
@@ -42,7 +42,7 @@ module Unwrappr
             let(:head_version) { GemVersion.new('1.1.0') }
 
             it "doesn't add data from Github" do
-              expect(research).to_not include(:github_comparison)
+              expect(research[:github_comparision]).to be_nil
             end
 
             it 'returns the data provided in gem_change_info' do
@@ -55,7 +55,7 @@ module Unwrappr
             let(:head_version) { nil }
 
             it "doesn't add data from Github" do
-              expect(research).to_not include(:github_comparison)
+              expect(research[:github_comparision]).to be_nil
             end
 
             it 'returns the data provided in gem_change_info' do
@@ -78,7 +78,7 @@ module Unwrappr
               end
 
               it 'returns the data from Github' do
-                expect(research).to include(github_comparison: response)
+                expect(research[:github_comparison]).to eq(response)
               end
 
               it 'returns the data provided in gem_change_info' do
@@ -97,7 +97,7 @@ module Unwrappr
               end
 
               it 'returns the data from Github' do
-                expect(research).to include(github_comparison: response)
+                expect(research[:github_comparison]).to eq(response)
               end
 
               it 'returns the data provided in gem_change_info' do

--- a/spec/lib/unwrappr/researchers/github_comparison_spec.rb
+++ b/spec/lib/unwrappr/researchers/github_comparison_spec.rb
@@ -37,18 +37,12 @@ module Unwrappr
         context 'given a Github repo' do
           let(:github_repo) { 'envato/unwrappr' }
 
-          context 'given the repo has "vx.x.x" tags' do
-            before do
-              allow(client).to receive(:compare)
-                .with('envato/unwrappr', 'v1.0.0', 'v1.1.0')
-                .and_return(response)
-              allow(client).to receive(:compare)
-                .with('envato/unwrappr', '1.0.0', '1.1.0')
-                .and_return(nil)
-            end
+          context 'given the gem is added' do
+            let(:base_version) { nil }
+            let(:head_version) { GemVersion.new('1.1.0') }
 
-            it 'returns the data from Github' do
-              expect(research).to include(github_comparison: response)
+            it "doesn't add data from Github" do
+              expect(research).to_not include(:github_comparison)
             end
 
             it 'returns the data provided in gem_change_info' do
@@ -56,22 +50,59 @@ module Unwrappr
             end
           end
 
-          context 'given the repo has "x.x.x" tags' do
-            before do
-              allow(client).to receive(:compare)
-                .with('envato/unwrappr', 'v1.0.0', 'v1.1.0')
-                .and_return(nil)
-              allow(client).to receive(:compare)
-                .with('envato/unwrappr', '1.0.0', '1.1.0')
-                .and_return(response)
-            end
+          context 'given the gem is removed' do
+            let(:base_version) { GemVersion.new('1.0.0') }
+            let(:head_version) { nil }
 
-            it 'returns the data from Github' do
-              expect(research).to include(github_comparison: response)
+            it "doesn't add data from Github" do
+              expect(research).to_not include(:github_comparison)
             end
 
             it 'returns the data provided in gem_change_info' do
               expect(research).to include(gem_change_info)
+            end
+          end
+
+          context 'given the gem version changed' do
+            let(:base_version) { GemVersion.new('1.0.0') }
+            let(:head_version) { GemVersion.new('1.1.0') }
+
+            context 'given the repo has "vx.x.x" tags' do
+              before do
+                allow(client).to receive(:compare)
+                  .with('envato/unwrappr', 'v1.0.0', 'v1.1.0')
+                  .and_return(response)
+                allow(client).to receive(:compare)
+                  .with('envato/unwrappr', '1.0.0', '1.1.0')
+                  .and_return(nil)
+              end
+
+              it 'returns the data from Github' do
+                expect(research).to include(github_comparison: response)
+              end
+
+              it 'returns the data provided in gem_change_info' do
+                expect(research).to include(gem_change_info)
+              end
+            end
+
+            context 'given the repo has "x.x.x" tags' do
+              before do
+                allow(client).to receive(:compare)
+                  .with('envato/unwrappr', 'v1.0.0', 'v1.1.0')
+                  .and_return(nil)
+                allow(client).to receive(:compare)
+                  .with('envato/unwrappr', '1.0.0', '1.1.0')
+                  .and_return(response)
+              end
+
+              it 'returns the data from Github' do
+                expect(research).to include(github_comparison: response)
+              end
+
+              it 'returns the data provided in gem_change_info' do
+                expect(research).to include(gem_change_info)
+              end
             end
           end
         end

--- a/spec/lib/unwrappr/researchers/github_comparison_spec.rb
+++ b/spec/lib/unwrappr/researchers/github_comparison_spec.rb
@@ -29,7 +29,7 @@ module Unwrappr
           let(:github_repo) { nil }
 
           it "doesn't add data from Github" do
-            expect(research).to_not include(:github_comparison)
+            expect(research[:github_comparision]).to be_nil
           end
 
           it 'returns the data provided in gem_change_info' do

--- a/spec/lib/unwrappr/researchers/github_comparison_spec.rb
+++ b/spec/lib/unwrappr/researchers/github_comparison_spec.rb
@@ -44,6 +44,11 @@ module Unwrappr
             let(:base_version) { nil }
             let(:head_version) { GemVersion.new('1.1.0') }
 
+            it "doesn't contact GitHub for a result we already know" do
+              research
+              expect(client).to_not have_received(:compare)
+            end
+
             it "doesn't add data from Github" do
               expect(research[:github_comparision]).to be_nil
             end
@@ -56,6 +61,11 @@ module Unwrappr
           context 'given the gem is removed' do
             let(:base_version) { GemVersion.new('1.0.0') }
             let(:head_version) { nil }
+
+            it "doesn't contact GitHub for a result we already know" do
+              research
+              expect(client).to_not have_received(:compare)
+            end
 
             it "doesn't add data from Github" do
               expect(research[:github_comparision]).to be_nil

--- a/spec/lib/unwrappr/researchers/github_comparison_spec.rb
+++ b/spec/lib/unwrappr/researchers/github_comparison_spec.rb
@@ -6,6 +6,9 @@ module Unwrappr
       subject(:github_comparison) { GithubComparison.new(client) }
 
       let(:client) { instance_double(Octokit::Client) }
+      before do
+        allow(client).to receive(:compare).and_raise(Octokit::NotFound)
+      end
 
       describe '#research' do
         subject(:research) { github_comparison.research(gem_change, gem_change_info) }
@@ -72,9 +75,6 @@ module Unwrappr
                 allow(client).to receive(:compare)
                   .with('envato/unwrappr', 'v1.0.0', 'v1.1.0')
                   .and_return(response)
-                allow(client).to receive(:compare)
-                  .with('envato/unwrappr', '1.0.0', '1.1.0')
-                  .and_return(nil)
               end
 
               it 'returns the data from Github' do
@@ -88,9 +88,6 @@ module Unwrappr
 
             context 'given the repo has "x.x.x" tags' do
               before do
-                allow(client).to receive(:compare)
-                  .with('envato/unwrappr', 'v1.0.0', 'v1.1.0')
-                  .and_return(nil)
                 allow(client).to receive(:compare)
                   .with('envato/unwrappr', '1.0.0', '1.1.0')
                   .and_return(response)


### PR DESCRIPTION
The `GithubComparison` object compares the old version of a gem to a new via the Github API: https://developer.github.com/v3/repos/commits/#compare-two-commits

When adding or removing a gem from the bundle we don't have two versions to compare. In this case there's no point calling the Github API. There'll definitely be no diff to obtain.

As an optimisation, let prevent this API call from happening.
