### PR TITLE
Enable executing unwrappr from a directory that does not include a Gemfile or .bundle

### DIFF
--- a/lib/unwrappr.rb
+++ b/lib/unwrappr.rb
@@ -2,6 +2,7 @@
 
 require 'unwrappr/bundler_command_runner'
 require 'unwrappr/cli'
+require 'unwrappr/environment'
 require 'unwrappr/gem_change'
 require 'unwrappr/gem_version'
 require 'unwrappr/git_command_runner'

--- a/lib/unwrappr/environment.rb
+++ b/lib/unwrappr/environment.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Unwrappr
+  # Facilitates interactions with environment variables.
+  module Environment
+    def self.with_environment_variable(name, value)
+      original_value = ENV[name]
+      ENV[name] = value
+      yield
+    ensure
+      ENV[name] = original_value
+    end
+  end
+end

--- a/lib/unwrappr/lock_file_comparator.rb
+++ b/lib/unwrappr/lock_file_comparator.rb
@@ -7,6 +7,14 @@ module Unwrappr
   module LockFileComparator
     class << self
       def perform(lock_file_content_before, lock_file_content_after)
+        Environment.with_environment_variable('BUNDLE_GEMFILE', 'Gemfile') do
+          compare(lock_file_content_before, lock_file_content_after)
+        end
+      end
+
+      private
+
+      def compare(lock_file_content_before, lock_file_content_after)
         lock_file_before = Bundler::LockfileParser.new(lock_file_content_before)
         lock_file_after = Bundler::LockfileParser.new(lock_file_content_after)
 
@@ -17,8 +25,6 @@ module Unwrappr
 
         { versions: versions_diff }
       end
-
-      private
 
       def specs_versions(lock_file)
         Hash[lock_file.specs.map { |s| [s.name.to_sym, s.version.to_s] }]

--- a/spec/lib/unwrappr/environment_spec.rb
+++ b/spec/lib/unwrappr/environment_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+module Unwrappr
+  RSpec.describe Environment do
+    describe 'temporary_environment' do
+      subject(:environment) { Environment.with_environment_variable(name, value, &block) }
+
+      let(:name) { 'MY_ENVIRONMENT_VARIABLE' }
+      let(:value) { 'my-environment-value' }
+      let(:block) { -> { block_return_value } }
+      let(:block_return_value) { 42 }
+
+      context 'given no prior environment variable set' do
+        it 'changes the environment to the new value (during the yield)' do
+          Environment.with_environment_variable(name, value) do
+            expect(ENV[name]).to eq(value)
+          end
+        end
+
+        it 'removes the environment variable' do
+          environment
+          expect(ENV[name]).to eq(nil)
+        end
+
+        it 'returns the value returned from the yield' do
+          expect(environment).to eq(block_return_value)
+        end
+      end
+
+      context 'given a prior environment variable set' do
+        let(:original_value) { 'an-existing-environment-value' }
+        before { ENV[name] = original_value }
+        after { ENV[name] = nil }
+
+        it 'changes the environment to the new value (during the yield)' do
+          Environment.with_environment_variable(name, value) do
+            expect(ENV[name]).to eq(value)
+          end
+        end
+
+        it 'restores the original value' do
+          environment
+          expect(ENV[name]).to eq(original_value)
+        end
+
+        it 'returns the value returned from the yield' do
+          expect(environment).to eq(block_return_value)
+        end
+
+        context 'and given the block raises an error' do
+          let(:block) { -> { raise 'an-example-error' } }
+
+          it 'raises the error' do
+            expect { environment }.to raise_error('an-example-error')
+          end
+
+          it 'restores the original value' do
+            expect { environment }.to raise_error('an-example-error')
+            expect(ENV[name]).to eq(original_value)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/unwrappr/lock_file_comparator_spec.rb
+++ b/spec/lib/unwrappr/lock_file_comparator_spec.rb
@@ -39,5 +39,22 @@ module Unwrappr
 
       expect(subject).to eql(expected_result)
     end
+
+    it 'sets the BUNDLE_GEMFILE variable before creating a LockfileParser '\
+       'to prevent Bundler looking for a Gemfile on the filesystem '\
+       'and raising if it fails to find it (#57)' do
+      allow(Bundler::LockfileParser).to receive(:new)
+        .with(lock_file_content_before) do
+        expect(ENV['BUNDLE_GEMFILE']).to eq('Gemfile')
+        lock_file_before
+      end
+      allow(Bundler::LockfileParser).to receive(:new)
+        .with(lock_file_content_after) do
+        expect(ENV['BUNDLE_GEMFILE']).to eq('Gemfile')
+        lock_file_after
+      end
+
+      perform
+    end
   end
 end


### PR DESCRIPTION
Set the `BUNDLE_GEMFILE` environment variable before comparing lock files. This prevents Bundler from looking for a `Gemfile` file or `.bundle` directory on the filesystem and raising an error if it does not find one.

Fixes #57.