### PR TITLE
Test against Ruby 2.6 and RubyGems 3.0

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,6 +1,15 @@
 ---
 
 steps:
+  - label: ":ruby: 2.6 :rspec:"
+    command: ".buildkite/steps/rspec.sh"
+    plugins:
+      docker#v1.2.1:
+        image: "ruby:2.6"
+    agents:
+      queue: "platform-docker-spot"
+    timeout_in_minutes: 5
+
   - label: ":ruby: 2.5 :rspec:"
     command: ".buildkite/steps/rspec.sh"
     plugins:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rvm:
   - 2.3.8
   - 2.4.5
   - 2.5.3
+  - 2.6.0
 before_install:
   - gem update --system
   - gem install bundler

--- a/unwrappr.gemspec
+++ b/unwrappr.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength:
   spec.homepage = 'http://www.unwrappr.com.org'
   spec.license = 'MIT'
   spec.required_ruby_version = '~> 2.3'
-  spec.required_rubygems_version = '~> 2.7'
+  spec.required_rubygems_version = '>= 2.7'
 
   spec.files = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})

--- a/unwrappr.gemspec
+++ b/unwrappr.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength:
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'bundler', '~> 1.16'
+  spec.add_dependency 'bundler', '>= 1.16'
   spec.add_dependency 'bundler-audit', '~> 0'
   spec.add_dependency 'clamp', '~> 1'
   spec.add_dependency 'faraday', '~> 0'


### PR DESCRIPTION
#### Context

https://www.ruby-lang.org/en/news/2018/12/25/ruby-2-6-0-released/ 

I had to change the `rubygems` specification to get Bundler to install the dependencies.

#### Change

 - Add 2.6.0 to the list of Rubies to build against.
