### PR TITLE
Test on Ruby 2.6

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,6 +1,15 @@
 ---
 
 steps:
+  - label: ":ruby: 2.6 :rspec:"
+    command: ".buildkite/steps/rspec.sh"
+    plugins:
+      docker#v1.2.1:
+        image: "ruby:2.6"
+    agents:
+      queue: "platform-docker-spot"
+    timeout_in_minutes: 5
+
   - label: ":ruby: 2.5 :rspec:"
     command: ".buildkite/steps/rspec.sh"
     plugins:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,6 @@ rvm:
   - 2.3.8
   - 2.4.5
   - 2.5.3
+  - 2.6.0
 before_install:
   - gem update --system


### PR DESCRIPTION
Ruby 2.6 has been [released](https://www.ruby-lang.org/en/news/2018/12/25/ruby-2-6-0-released/)! Let's add it to the test matrix.

![image](https://user-images.githubusercontent.com/497874/51799290-dadcd600-2273-11e9-8dc2-9b316a400872.png)
