### PR TITLE
Handle gems with dots in their name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Fix failure to annotate gem change with '.' in its name.
 
 ## [0.3.3] 2019-06-07
 - Fix issue where gem install will now work on RubyGems v3

--- a/lib/unwrappr/lock_file_diff.rb
+++ b/lib/unwrappr/lock_file_diff.rb
@@ -63,7 +63,7 @@ module Unwrappr
       # '+    websocket-driver (0.6.5)'
       # Careful not to match this (note the wider indent):
       # '+      websocket-extensions (>= 0.1.0)'
-      pattern = /^(?<change_type>[\+\-])    (?<gem_name>[\w-]+) \(\d/
+      pattern = /^(?<change_type>[\+\-])    (?<gem_name>[\S-]+) \(\d/
       match = pattern.match(line)
       return match[:gem_name], match[:change_type] unless match.nil?
     end

--- a/lib/unwrappr/lock_file_diff.rb
+++ b/lib/unwrappr/lock_file_diff.rb
@@ -63,7 +63,7 @@ module Unwrappr
       # '+    websocket-driver (0.6.5)'
       # Careful not to match this (note the wider indent):
       # '+      websocket-extensions (>= 0.1.0)'
-      pattern = /^(?<change_type>[\+\-])    (?<gem_name>[\S-]+) \(\d/
+      pattern = /^(?<change_type>[\+\-])    (?<gem_name>[\S]+) \(\d/
       match = pattern.match(line)
       return match[:gem_name], match[:change_type] unless match.nil?
     end

--- a/spec/lib/unwrappr/lock_file_diff_spec.rb
+++ b/spec/lib/unwrappr/lock_file_diff_spec.rb
@@ -121,11 +121,11 @@ module Unwrappr
       end
 
       it 'yields the correct number of gem changes' do
-        expect(gem_changes.count).to eq(7)
+        expect(gem_changes.count).to eq(8)
       end
 
-      describe '1st' do
-        subject(:first_gem_change) { gem_changes[0] }
+      describe '1st change' do
+        subject(:gem_change) { gem_changes[0] }
         its(:name) { should eq('diff_lcs') }
         it { should be_removed }
         its(:line_number) { should eq 4 }
@@ -133,8 +133,8 @@ module Unwrappr
         its(:head_version) { should be_nil }
       end
 
-      describe '2nd' do
-        subject(:second_gem_change) { gem_changes[1] }
+      describe '2nd change' do
+        subject(:gem_change) { gem_changes[1] }
         its(:name) { should eq('i18n') }
         it { should be_upgrade }
         it { should be_minor }
@@ -143,8 +143,8 @@ module Unwrappr
         its(:head_version) { should eq GemVersion.new('1.1.0') }
       end
 
-      describe '3rd' do
-        subject(:second_gem_change) { gem_changes[2] }
+      describe '3rd change' do
+        subject(:gem_change) { gem_changes[2] }
         its(:name) { should eq('pry') }
         it { should be_added }
         its(:line_number) { should eq 6 }
@@ -152,8 +152,8 @@ module Unwrappr
         its(:head_version) { should eq GemVersion.new('0.11.3') }
       end
 
-      describe '4th' do
-        subject(:third_gem_change) { gem_changes[3] }
+      describe '4th change' do
+        subject(:gem_change) { gem_changes[3] }
         its(:name) { should eq('rspec') }
         it { should be_upgrade }
         it { should be_major }
@@ -162,8 +162,8 @@ module Unwrappr
         its(:head_version) { should eq GemVersion.new('4.0.0') }
       end
 
-      describe '5th' do
-        subject(:fourth_gem_change) { gem_changes[4] }
+      describe '5th change' do
+        subject(:gem_change) { gem_changes[4] }
         its(:name) { should eq('rspec-expectations') }
         it { should be_upgrade }
         it { should be_minor }
@@ -172,8 +172,8 @@ module Unwrappr
         its(:head_version) { should eq GemVersion.new('3.8.0') }
       end
 
-      describe '6th' do
-        subject(:fifth_gem_change) { gem_changes[5] }
+      describe '6th change' do
+        subject(:gem_change) { gem_changes[5] }
         its(:name) { should eq('rspec-mocks') }
         it { should be_downgrade }
         it { should be_minor }
@@ -182,8 +182,8 @@ module Unwrappr
         its(:head_version) { should eq GemVersion.new('3.6.0') }
       end
 
-      describe '7th' do
-        subject(:sixth_gem_change) { gem_changes[6] }
+      describe '7th change' do
+        subject(:gem_change) { gem_changes[6] }
         its(:name) { should eq('rspec-support') }
         it { should be_upgrade }
         it { should be_patch }

--- a/spec/lib/unwrappr/lock_file_diff_spec.rb
+++ b/spec/lib/unwrappr/lock_file_diff_spec.rb
@@ -39,6 +39,7 @@ module Unwrappr
       -    rspec-support (3.7.0)
       +    rspec-support (3.7.1)
            highline (2.0.0)
+      -    http_parser.rb (0.6.0)
       -    i18n (1.0.1)
       +    i18n (1.1.0)
 
@@ -71,6 +72,7 @@ module Unwrappr
             rspec-support (~> 3.7.0)
           rspec-support (3.7.0)
           highline (2.0.0)
+          http_parser.rb (0.6.0)
           i18n (1.0.1)
 
       PLATFORMS
@@ -135,16 +137,25 @@ module Unwrappr
 
       describe '2nd change' do
         subject(:gem_change) { gem_changes[1] }
-        its(:name) { should eq('i18n') }
-        it { should be_upgrade }
-        it { should be_minor }
-        its(:line_number) { should eq 27 }
-        its(:base_version) { should eq GemVersion.new('1.0.1') }
-        its(:head_version) { should eq GemVersion.new('1.1.0') }
+        its(:name) { should eq('http_parser.rb') }
+        it { should be_removed }
+        its(:line_number) { should eq 26 }
+        its(:base_version) { should eq GemVersion.new('0.6.0') }
+        its(:head_version) { should be_nil }
       end
 
       describe '3rd change' do
         subject(:gem_change) { gem_changes[2] }
+        its(:name) { should eq('i18n') }
+        it { should be_upgrade }
+        it { should be_minor }
+        its(:line_number) { should eq 28 }
+        its(:base_version) { should eq GemVersion.new('1.0.1') }
+        its(:head_version) { should eq GemVersion.new('1.1.0') }
+      end
+
+      describe '4th change' do
+        subject(:gem_change) { gem_changes[3] }
         its(:name) { should eq('pry') }
         it { should be_added }
         its(:line_number) { should eq 6 }
@@ -152,8 +163,8 @@ module Unwrappr
         its(:head_version) { should eq GemVersion.new('0.11.3') }
       end
 
-      describe '4th change' do
-        subject(:gem_change) { gem_changes[3] }
+      describe '5th change' do
+        subject(:gem_change) { gem_changes[4] }
         its(:name) { should eq('rspec') }
         it { should be_upgrade }
         it { should be_major }
@@ -162,8 +173,8 @@ module Unwrappr
         its(:head_version) { should eq GemVersion.new('4.0.0') }
       end
 
-      describe '5th change' do
-        subject(:gem_change) { gem_changes[4] }
+      describe '6th change' do
+        subject(:gem_change) { gem_changes[5] }
         its(:name) { should eq('rspec-expectations') }
         it { should be_upgrade }
         it { should be_minor }
@@ -172,8 +183,8 @@ module Unwrappr
         its(:head_version) { should eq GemVersion.new('3.8.0') }
       end
 
-      describe '6th change' do
-        subject(:gem_change) { gem_changes[5] }
+      describe '7th change' do
+        subject(:gem_change) { gem_changes[6] }
         its(:name) { should eq('rspec-mocks') }
         it { should be_downgrade }
         it { should be_minor }
@@ -182,8 +193,8 @@ module Unwrappr
         its(:head_version) { should eq GemVersion.new('3.6.0') }
       end
 
-      describe '7th change' do
-        subject(:gem_change) { gem_changes[6] }
+      describe '8th change' do
+        subject(:gem_change) { gem_changes[7] }
         its(:name) { should eq('rspec-support') }
         it { should be_upgrade }
         it { should be_patch }


### PR DESCRIPTION
### Context

The gem change annotation process fails when encountering a gem with a `.` in its name.

```
Octokit::UnprocessableEntity: POST https://api.github.com/repos/envato/marketplace/pulls/25214/comments: 422 - Invalid request.
--
  |  
  | No subschema in "oneOf" matched.
  | For 'properties/position', nil is not an integer.
  | "in_reply_to" wasn't supplied.
  | "position" is not a permitted key.
  | "line" wasn't supplied. // See: https://developer.github.com/v3/pulls/comments/#create-a-comment
  | /usr/local/bundle/gems/octokit-4.14.0/lib/octokit/response/raise_error.rb:16:in `on_complete'
  | /usr/local/bundle/gems/faraday-0.17.0/lib/faraday/response.rb:9:in `block in call'
  | /usr/local/bundle/gems/faraday-0.17.0/lib/faraday/response.rb:61:in `on_complete'
  | /usr/local/bundle/gems/faraday-0.17.0/lib/faraday/response.rb:8:in `call'
  | /usr/local/bundle/gems/octokit-4.14.0/lib/octokit/middleware/follow_redirects.rb:73:in `perform_with_redirection'
  | /usr/local/bundle/gems/octokit-4.14.0/lib/octokit/middleware/follow_redirects.rb:61:in `call'
  | /usr/local/bundle/gems/faraday-0.17.0/lib/faraday/request/retry.rb:130:in `call'
  | /usr/local/bundle/gems/faraday-0.17.0/lib/faraday/rack_builder.rb:143:in `build_response'
  | /usr/local/bundle/gems/faraday-0.17.0/lib/faraday/connection.rb:387:in `run_request'
  | /usr/local/bundle/gems/faraday-0.17.0/lib/faraday/connection.rb:175:in `post'
  | /usr/local/bundle/gems/sawyer-0.8.2/lib/sawyer/agent.rb:94:in `call'
  | /usr/local/bundle/gems/octokit-4.14.0/lib/octokit/connection.rb:156:in `request'
  | /usr/local/bundle/gems/octokit-4.14.0/lib/octokit/connection.rb:28:in `post'
  | /usr/local/bundle/gems/octokit-4.14.0/lib/octokit/client/pull_requests.rb:213:in `create_pull_request_comment'
  | /usr/local/bundle/gems/unwrappr-0.3.3/lib/unwrappr/github/pr_sink.rb:17:in `annotate_change'
  | /usr/local/bundle/gems/unwrappr-0.3.3/lib/unwrappr/lock_file_annotator.rb:60:in `block (2 levels) in annotate'
  | /usr/local/bundle/gems/unwrappr-0.3.3/lib/unwrappr/lock_file_diff.rb:19:in `block in each_gem_change'
  | /usr/local/bundle/gems/unwrappr-0.3.3/lib/unwrappr/lock_file_diff.rb:18:in `each'
  | /usr/local/bundle/gems/unwrappr-0.3.3/lib/unwrappr/lock_file_diff.rb:18:in `each_gem_change'
  | /usr/local/bundle/gems/unwrappr-0.3.3/lib/unwrappr/lock_file_annotator.rb:57:in `block in annotate'
  | /usr/local/bundle/gems/unwrappr-0.3.3/lib/unwrappr/github/pr_source.rb:20:in `block in each_file'
  | /usr/local/bundle/gems/unwrappr-0.3.3/lib/unwrappr/github/pr_source.rb:19:in `each'
  | /usr/local/bundle/gems/unwrappr-0.3.3/lib/unwrappr/github/pr_source.rb:19:in `each_file'
  | /usr/local/bundle/gems/unwrappr-0.3.3/lib/unwrappr/lock_file_annotator.rb:56:in `annotate'
  | /usr/local/bundle/gems/unwrappr-0.3.3/lib/unwrappr/lock_file_annotator.rb:39:in `annotate_github_pull_request'
  | /usr/local/bundle/gems/unwrappr-0.3.3/lib/unwrappr/cli.rb:34:in `execute'
  | /usr/local/bundle/gems/clamp-1.3.1/lib/clamp/command.rb:66:in `run'
  | /usr/local/bundle/gems/clamp-1.3.1/lib/clamp/subcommand/execution.rb:18:in `execute'
  | /usr/local/bundle/gems/clamp-1.3.1/lib/clamp/command.rb:66:in `run'
  | /usr/local/bundle/gems/clamp-1.3.1/lib/clamp/command.rb:140:in `run'
  | /usr/local/bundle/gems/unwrappr-0.3.3/exe/unwrappr:11:in `<top (required)>'
  | /usr/local/bundle/bin/unwrappr:23:in `load'
  | /usr/local/bundle/bin/unwrappr:23:in `<top (required)>'
```

It seems it couldn't determine the diff line number on which to add the annotation.


### Change

Support annotating gem changes, where the gem name includes a `.`.


