### PR TITLE
ISO 8601 Date and time format for branch name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 [Unreleased]: https://github.com/envato/unwrappr/compare/v0.3.4...HEAD
+### Changed
+- ISO 8601 Date and time format for branch name ([#68])
 
 ## [0.3.4] 2019-10-24
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [Unreleased]: https://github.com/envato/unwrappr/compare/v0.3.4...HEAD
 ### Changed
 - ISO 8601 Date and time format for branch name ([#68])
+[#68]: https://github.com/envato/unwrappr/pull/68
 
 ## [0.3.4] 2019-10-24
 ### Fixed

--- a/lib/unwrappr/git_command_runner.rb
+++ b/lib/unwrappr/git_command_runner.rb
@@ -51,7 +51,7 @@ module Unwrappr
       end
 
       def branch_created?
-        timestamp = Time.now.strftime('%Y%d%m-%H%M').freeze
+        timestamp = Time.now.strftime('%Y%m%d-%H%M').freeze
         git_wrap do
           git.checkout('origin/master')
           git.branch("auto_bundle_update_#{timestamp}").checkout

--- a/spec/lib/unwrappr/git_command_runner_spec.rb
+++ b/spec/lib/unwrappr/git_command_runner_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Unwrappr::GitCommandRunner do
   describe '#create_branch!' do
     subject(:create_branch!) { described_class.create_branch! }
 
-    before { allow(Time).to receive(:now).and_return(Time.parse('2017-01-01 11:23')) }
+    before { allow(Time).to receive(:now).and_return(Time.parse('2017-11-01 11:23')) }
 
     context 'Given current directory is not a git repo' do
       before do
@@ -32,7 +32,7 @@ RSpec.describe Unwrappr::GitCommandRunner do
       end
 
       it 'checks out a new branch based on origin/master, with a timestamp' do
-        expect(fake_git).to receive(:branch).with('auto_bundle_update_20170101-1123').and_return(fake_git)
+        expect(fake_git).to receive(:branch).with('auto_bundle_update_20171101-1123').and_return(fake_git)
 
         expect(fake_git).to receive(:checkout).with(no_args)
 

--- a/spec/lib/unwrappr/git_command_runner_spec.rb
+++ b/spec/lib/unwrappr/git_command_runner_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Unwrappr::GitCommandRunner do
       context 'When there is some failure in creating the branch' do
         before do
           expect(fake_git).to receive(:branch)
-            .with('auto_bundle_update_20170101-1123')
+            .with('auto_bundle_update_20171101-1123')
             .and_raise(Git::GitExecuteError)
         end
 


### PR DESCRIPTION
Tiniest nitpick but when trying to check out a branch locally, I was surprised when my shell's autocompletion expected a `2` after `2019` and not a `1` for a branch created on 20 November.