### PR TITLE
Gem version specific information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ISO 8601 Date and time format for branch name ([#68])
 ### Fixed
 - Changelog and source links in PR annotation are specific to the version
-  used in the project, not the latest available on Rubygems.org ([#69]).
+  used in the project, not just the latest available on Rubygems.org ([#69]).
 
 [Unreleased]: https://github.com/envato/unwrappr/compare/v0.3.4...HEAD
 [#68]: https://github.com/envato/unwrappr/pull/68

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
-[Unreleased]: https://github.com/envato/unwrappr/compare/v0.3.4...HEAD
 ### Changed
 - ISO 8601 Date and time format for branch name ([#68])
+### Fixed
+- Changelog and source links in PR annotation are specific to the version
+  used in the project, not the latest available on Rubygems.org ([#69]).
+
+[Unreleased]: https://github.com/envato/unwrappr/compare/v0.3.4...HEAD
 [#68]: https://github.com/envato/unwrappr/pull/68
+[#69]: https://github.com/envato/unwrappr/pull/69
 
 ## [0.3.4] 2019-10-24
 ### Fixed

--- a/lib/unwrappr/researchers/ruby_gems_info.rb
+++ b/lib/unwrappr/researchers/ruby_gems_info.rb
@@ -9,7 +9,9 @@ module Unwrappr
     class RubyGemsInfo
       def research(gem_change, gem_change_info)
         gem_change_info.merge(
-          ruby_gems: ::Unwrappr::RubyGems.gem_info(gem_change.name)
+          ruby_gems: ::Unwrappr::RubyGems.gem_info(
+            gem_change.name, gem_change.head_version
+          )
         )
       end
     end

--- a/lib/unwrappr/ruby_gems.rb
+++ b/lib/unwrappr/ruby_gems.rb
@@ -13,10 +13,6 @@ module Unwrappr
         parse(Faraday.get(SERVER + GET_GEM % name), name)
       end
 
-      def try_get_source_code_uri(gem_name)
-        Unwrappr::RubyGems.gem_info(gem_name)&.source_code_uri
-      end
-
       private
 
       def parse(response, name)

--- a/lib/unwrappr/ruby_gems.rb
+++ b/lib/unwrappr/ruby_gems.rb
@@ -6,11 +6,11 @@ module Unwrappr
   # A wrapper around RubyGems' API
   module RubyGems
     SERVER = 'https://rubygems.org'
-    GET_GEM = '/api/v1/gems/%s.json'
+    GET_GEM = '/api/v2/rubygems/%s/versions/%s.json'
 
     class << self
-      def gem_info(name)
-        parse(Faraday.get(SERVER + GET_GEM % name), name)
+      def gem_info(name, version)
+        parse(Faraday.get(SERVER + format(GET_GEM, name, version)), name)
       end
 
       private

--- a/spec/lib/unwrappr/lock_file_annotator_spec.rb
+++ b/spec/lib/unwrappr/lock_file_annotator_spec.rb
@@ -96,7 +96,7 @@ module Unwrappr
 
         before do
           allow(::Unwrappr::RubyGems).to receive(:gem_info)
-            .with('rspec-support')
+            .with('rspec-support', GemVersion.new('3.7.1'))
             .and_return(spy(homepage_uri: 'home-uri',
                             source_code_uri: 'source-uri',
                             changelog_uri: 'changelog-uri'))

--- a/spec/lib/unwrappr/researchers/ruby_gems_info_spec.rb
+++ b/spec/lib/unwrappr/researchers/ruby_gems_info_spec.rb
@@ -9,9 +9,10 @@ module Unwrappr
         ruby_gems_info.research(gem_change, gem_change_info)
       end
 
-      let(:gem_change) { instance_double(GemChange, name: gem_name) }
+      let(:gem_change) { instance_double(GemChange, name: gem_name, head_version: gem_version) }
       let(:gem_change_info) { { something_existing: 'random' } }
       let(:gem_name) { 'test-name' }
+      let(:gem_version) { GemVersion.new('7.3.15') }
       let(:info) { 'this-is-the-info-from-rubygems' }
 
       before do
@@ -20,7 +21,7 @@ module Unwrappr
 
       it 'queries RubyGems using the gem name' do
         research
-        expect(::Unwrappr::RubyGems).to have_received(:gem_info).with(gem_name)
+        expect(::Unwrappr::RubyGems).to have_received(:gem_info).with(gem_name, gem_version)
       end
 
       it 'returns the data from RubyGems' do

--- a/spec/lib/unwrappr/ruby_gems_spec.rb
+++ b/spec/lib/unwrappr/ruby_gems_spec.rb
@@ -2,8 +2,9 @@
 
 module Unwrappr
   RSpec.describe RubyGems do
-    subject(:gem_info) { described_class.gem_info(gem_name) }
+    subject(:gem_info) { described_class.gem_info(gem_name, gem_version) }
     let(:gem_name) { 'gem_name' }
+    let(:gem_version) { GemVersion.new('17.53.125') }
 
     let(:response) { double('faraday_response', status: response_status, body: response_body) }
     let(:response_status) { 200 }
@@ -16,7 +17,7 @@ module Unwrappr
     context 'connectivity' do
       it 'requests rubygems.org API' do
         expect(Faraday).to receive(:get)
-          .with('https://rubygems.org/api/v1/gems/gem_name.json')
+          .with('https://rubygems.org/api/v2/rubygems/gem_name/versions/17.53.125.json')
 
         gem_info
       end


### PR DESCRIPTION
#### Context

On a recent update, I noticed the wrong source and changelog links were being provided.

![image](https://user-images.githubusercontent.com/497874/69767434-5bd86700-11d0-11ea-8365-b563bfcad634.png)

On an update to activesupport version 5.2.4, the changelog and source links were for version 6.0.1.

changelog: https://github.com/rails/rails/blob/v6.0.1/activesupport/CHANGELOG.md
source: https://github.com/rails/rails/tree/v6.0.1/activesupport

It turns out when asking for gem information from Rubygems.org, we don't provide a version. Hence, Rubygems.org provides information for the latest version available.

#### Change

Pass the version through in the API call to Rubygems.org. So we get the appropriate information for the specific gem version the project is changing to.