### PR TITLE
Limit bundler-audit versions to >= 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- `bundler-audit` limited to `>= 0.6.0` ([#71])
 
 [Unreleased]: https://github.com/envato/unwrappr/compare/v0.3.5...HEAD
+[#71]: https://github.com/envato/unwrappr/pull/71
 
 ## [0.3.5] 2019-11-28
 ### Changed

--- a/unwrappr.gemspec
+++ b/unwrappr.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength:
   spec.require_paths = ['lib']
 
   spec.add_dependency 'bundler', '< 3'
-  spec.add_dependency 'bundler-audit', '~> 0'
+  spec.add_dependency 'bundler-audit', '>= 0.6.0'
   spec.add_dependency 'clamp', '~> 1'
   spec.add_dependency 'faraday', '~> 0'
   spec.add_dependency 'git', '~> 1'


### PR DESCRIPTION
`unwrappr` is incompatible with earlier versions of `bundler-audit`: explicitly the `Bundler::Audit::Database.update!` method started accepting an argument in later versions, which `unwrappr` is providing.

https://github.com/envato/unwrappr/blob/84c4ef351911c63deafe0b6eaafa8b65c5025920/lib/unwrappr/researchers/security_vulnerabilities.rb#L37