### PR TITLE
Rake vulnerability CVE-2020-8130 fixes

### DIFF
--- a/unwrappr.gemspec
+++ b/unwrappr.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength:
   spec.add_development_dependency 'guard', '~> 2'
   spec.add_development_dependency 'guard-rspec', '~> 4'
   spec.add_development_dependency 'pry', '~> 0'
-  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rake', '>= 12.3.3'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rspec-its', '~> 1'
   spec.add_development_dependency 'rubocop', '>= 0.49.0'


### PR DESCRIPTION
This PR fixes [CVE-2020-8130](https://nvd.nist.gov/vuln/detail/CVE-2020-8130) by updating rake development dependency version to `>= 12.3.3`

![image](https://user-images.githubusercontent.com/21890/75643259-8e43a580-5c92-11ea-9ac3-fb55cfc27d8f.png)

