### PR TITLE
Handle Rails version numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `bundler-audit` limited to `>= 0.6.0` ([#71])
 
 ### Removed
-- Support for Ruby 2.3 and 2.4
+- Support for Ruby 2.3 and 2.4 ([#73])
 
 ### Added
-- Support for Ruby 2.6 and 2.7
+- Rake vulnerability CVE-2020-8130 fixes ([#72])
+- Support for Ruby 2.6 and 2.7 ([#73])
+- Support for version numbers including a fourth segment (_e.g._ "6.0.2.2") ([#74])
 
 [Unreleased]: https://github.com/envato/unwrappr/compare/v0.3.5...HEAD
 [#71]: https://github.com/envato/unwrappr/pull/71
+[#72]: https://github.com/envato/unwrappr/pull/72
+[#73]: https://github.com/envato/unwrappr/pull/73
+[#74]: https://github.com/envato/unwrappr/pull/74
 
 ## [0.3.5] 2019-11-28
 ### Changed

--- a/lib/unwrappr/gem_change.rb
+++ b/lib/unwrappr/gem_change.rb
@@ -43,6 +43,11 @@ module Unwrappr
         head_version.patch_difference?(base_version)
     end
 
+    def hotfix?
+      head_version && base_version &&
+        head_version.hotfix_difference?(base_version)
+    end
+
     def upgrade?
       head_version && base_version && (head_version > base_version)
     end

--- a/lib/unwrappr/gem_version.rb
+++ b/lib/unwrappr/gem_version.rb
@@ -13,9 +13,10 @@ module Unwrappr
       @major = segment(0)
       @minor = segment(1)
       @patch = segment(2)
+      @hotfix = segment(3)
     end
 
-    attr_reader :major, :minor, :patch, :version
+    attr_reader :major, :minor, :patch, :hotfix, :version
 
     def major_difference?(other)
       (major != other.major)
@@ -30,6 +31,13 @@ module Unwrappr
       (major == other.major) &&
         (minor == other.minor) &&
         (patch != other.patch)
+    end
+
+    def hotfix_difference?(other)
+      (major == other.major) &&
+        (minor == other.minor) &&
+        (patch == other.patch) &&
+        (hotfix != other.hotfix)
     end
 
     def <=>(other)

--- a/lib/unwrappr/writers/version_change.rb
+++ b/lib/unwrappr/writers/version_change.rb
@@ -31,9 +31,17 @@ module Unwrappr
                      :upgrade?, :downgrade?, :base_version, :head_version)
 
       def change_description
-        if added? then 'Gem added :snowman:'
-        elsif removed? then 'Gem removed :fire:'
-        elsif major?
+        if added?
+          'Gem added :snowman:'
+        elsif removed?
+          'Gem removed :fire:'
+        else
+          version_description
+        end
+      end
+
+      def version_description
+        if major?
           "**Major** version #{grade}:exclamation: #{version_diff}"
         elsif minor?
           "**Minor** version #{grade}:large_orange_diamond: #{version_diff}"

--- a/lib/unwrappr/writers/version_change.rb
+++ b/lib/unwrappr/writers/version_change.rb
@@ -27,7 +27,7 @@ module Unwrappr
       private
 
       def_delegators(:@gem_change,
-                     :added?, :removed?, :major?, :minor?, :patch?,
+                     :added?, :removed?, :major?, :minor?, :patch?, :hotfix?,
                      :upgrade?, :downgrade?, :base_version, :head_version)
 
       def change_description
@@ -39,6 +39,8 @@ module Unwrappr
           "**Minor** version #{grade}:large_orange_diamond: #{version_diff}"
         elsif patch?
           "**Patch** version #{grade}:small_blue_diamond: #{version_diff}"
+        elsif hotfix?
+          "**Hotfix** version #{grade}:small_red_triangle: #{version_diff}"
         end
       end
 

--- a/spec/lib/unwrappr/gem_version_spec.rb
+++ b/spec/lib/unwrappr/gem_version_spec.rb
@@ -2,12 +2,13 @@
 
 module Unwrappr
   RSpec.describe GemVersion do
-    describe 'major, minor, patch' do
+    describe 'major, minor, patch, hotfix' do
       context 'given 4.2.7' do
         subject(:version) { GemVersion.new('4.2.7') }
         its(:major) { should be(4) }
         its(:minor) { should be(2) }
         its(:patch) { should be(7) }
+        its(:hotfix) { should be(0) }
       end
 
       context 'given 5.1' do
@@ -15,6 +16,7 @@ module Unwrappr
         its(:major) { should be(5) }
         its(:minor) { should be(1) }
         its(:patch) { should be(0) }
+        its(:hotfix) { should be(0) }
       end
 
       context 'given 7' do
@@ -22,6 +24,7 @@ module Unwrappr
         its(:major) { should be(7) }
         its(:minor) { should be(0) }
         its(:patch) { should be(0) }
+        its(:hotfix) { should be(0) }
       end
 
       context 'given 12.5.19-beta' do
@@ -29,6 +32,7 @@ module Unwrappr
         its(:major) { should be(12) }
         its(:minor) { should be(5) }
         its(:patch) { should be(19) }
+        its(:hotfix) { should be_nil }
       end
 
       context 'given 1.235-alpha' do
@@ -36,6 +40,7 @@ module Unwrappr
         its(:major) { should be(1) }
         its(:minor) { should be(235) }
         its(:patch) { should be_nil }
+        its(:hotfix) { should be_nil }
       end
     end
 
@@ -45,6 +50,7 @@ module Unwrappr
         it { should be < GemVersion.new('4.2.8') }
         it { should be < GemVersion.new('4.3.6') }
         it { should be < GemVersion.new('5.1.6') }
+        it { should be < GemVersion.new('4.2.7.1') }
       end
     end
 
@@ -52,6 +58,7 @@ module Unwrappr
       context '4.2.7' do
         subject(:version) { GemVersion.new('4.2.7') }
         it { should be > GemVersion.new('4.2.6') }
+        it { should be > GemVersion.new('4.2.6.99') }
         it { should be > GemVersion.new('4.1.8') }
         it { should be > GemVersion.new('3.3.8') }
       end
@@ -60,35 +67,54 @@ module Unwrappr
     describe '#major_difference' do
       context '4.2.7' do
         subject(:version) { GemVersion.new('4.2.7') }
-        it { should be_major_difference(GemVersion.new('5.2.7')) }
         it { should be_major_difference(GemVersion.new('3.2.7')) }
+        it { should be_major_difference(GemVersion.new('5.2.7')) }
         it { should be_major_difference(GemVersion.new('5.3.8')) }
         it { should_not be_major_difference(GemVersion.new('4.2.7')) }
-        it { should_not be_major_difference(GemVersion.new('4.3.7')) }
+        it { should_not be_major_difference(GemVersion.new('4.2.7.99')) }
         it { should_not be_major_difference(GemVersion.new('4.2.8')) }
+        it { should_not be_major_difference(GemVersion.new('4.3.7')) }
       end
     end
 
     describe '#minor_difference' do
       context '4.2.7' do
         subject(:version) { GemVersion.new('4.2.7') }
-        it { should be_minor_difference(GemVersion.new('4.3.7')) }
         it { should be_minor_difference(GemVersion.new('4.1.7')) }
+        it { should be_minor_difference(GemVersion.new('4.3.7')) }
         it { should be_minor_difference(GemVersion.new('4.3.8')) }
         it { should_not be_minor_difference(GemVersion.new('4.2.7')) }
-        it { should_not be_minor_difference(GemVersion.new('5.3.7')) }
+        it { should_not be_minor_difference(GemVersion.new('4.2.7.99')) }
         it { should_not be_minor_difference(GemVersion.new('4.2.8')) }
+        it { should_not be_minor_difference(GemVersion.new('5.3.7')) }
       end
     end
 
     describe '#patch_difference' do
       context '4.2.7' do
         subject(:version) { GemVersion.new('4.2.7') }
-        it { should be_patch_difference(GemVersion.new('4.2.8')) }
         it { should be_patch_difference(GemVersion.new('4.2.6')) }
+        it { should be_patch_difference(GemVersion.new('4.2.8')) }
         it { should_not be_patch_difference(GemVersion.new('4.2.7')) }
-        it { should_not be_patch_difference(GemVersion.new('5.2.8')) }
+        it { should_not be_patch_difference(GemVersion.new('4.2.7.99')) }
         it { should_not be_patch_difference(GemVersion.new('4.3.8')) }
+        it { should_not be_patch_difference(GemVersion.new('5.2.8')) }
+      end
+    end
+
+    describe '#hotfix_difference' do
+      context '4.2.7.0' do
+        subject(:version) { GemVersion.new('4.2.7.0') }
+        it { should be_hotfix_difference(GemVersion.new('4.2.7.99')) }
+        it { should_not be_hotfix_difference(GemVersion.new('4.2.6')) }
+        it { should_not be_hotfix_difference(GemVersion.new('4.2.6.99')) }
+        it { should_not be_hotfix_difference(GemVersion.new('4.2.7')) }
+        it { should_not be_hotfix_difference(GemVersion.new('4.2.8')) }
+        it { should_not be_hotfix_difference(GemVersion.new('4.2.8.99')) }
+        it { should_not be_hotfix_difference(GemVersion.new('4.3.8')) }
+        it { should_not be_hotfix_difference(GemVersion.new('4.3.8.99')) }
+        it { should_not be_hotfix_difference(GemVersion.new('5.2.8')) }
+        it { should_not be_hotfix_difference(GemVersion.new('5.2.8.99')) }
       end
     end
   end

--- a/spec/lib/unwrappr/writers/version_change_spec.rb
+++ b/spec/lib/unwrappr/writers/version_change_spec.rb
@@ -15,15 +15,6 @@ module Unwrappr
         end
         let(:gem_change_info) { {} }
 
-        context 'change from 4.2.0 to 4.2.1' do
-          let(:base_version) { GemVersion.new('4.2.0') }
-          let(:head_version) { GemVersion.new('4.2.1') }
-
-          it { should eq <<~MESSAGE }
-            **Patch** version upgrade :chart_with_upwards_trend::small_blue_diamond: 4.2.0 → 4.2.1
-          MESSAGE
-        end
-
         context 'change from 3.9.0 to 4.0.5' do
           let(:base_version) { GemVersion.new('3.9.0') }
           let(:head_version) { GemVersion.new('4.0.5') }
@@ -39,6 +30,24 @@ module Unwrappr
 
           it { should eq <<~MESSAGE }
             **Minor** version downgrade :chart_with_downwards_trend::exclamation::large_orange_diamond: 3.9.0 → 3.8.5
+          MESSAGE
+        end
+
+        context 'change from 4.2.0 to 4.2.1' do
+          let(:base_version) { GemVersion.new('4.2.0') }
+          let(:head_version) { GemVersion.new('4.2.1') }
+
+          it { should eq <<~MESSAGE }
+            **Patch** version upgrade :chart_with_upwards_trend::small_blue_diamond: 4.2.0 → 4.2.1
+          MESSAGE
+        end
+
+        context 'change from 6.0.2.2 to 6.0.2.1' do
+          let(:base_version) { GemVersion.new('6.0.2.2') }
+          let(:head_version) { GemVersion.new('6.0.2.1') }
+
+          it { should eq <<~MESSAGE }
+            **Hotfix** version downgrade :chart_with_downwards_trend::exclamation::small_red_triangle: 6.0.2.2 → 6.0.2.1
           MESSAGE
         end
 


### PR DESCRIPTION
#### Context

[Rails follows a shifted version of semver](https://guides.rubyonrails.org/maintenance_policy.html) and recently released [v6.0.2.1](https://github.com/rails/rails/blob/v6.0.2.2/actionview/CHANGELOG.md#rails-6021-december-18-2019) and v6.0.2.2, which [unwrappr didn't annotate as an upgrade](https://github.com/envato/unwrappr-demo/pull/9#discussion_r398209204).

I can find no naming convention for this fourth segment, but "hotfix" feels right here.

#### Change

Handle a fourth segment in version numbers as "hotfix" versions.