### PR TITLE
Handle anchors in homepage URI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rake vulnerability CVE-2020-8130 fixes ([#72])
 - Support for Ruby 2.6 and 2.7 ([#73])
 - Support for version numbers including a fourth segment (_e.g._ "6.0.2.2") ([#74])
+- Support for GitHub URIs including anchors ([#75])
 
 [Unreleased]: https://github.com/envato/unwrappr/compare/v0.3.5...HEAD
 [#71]: https://github.com/envato/unwrappr/pull/71
 [#72]: https://github.com/envato/unwrappr/pull/72
 [#73]: https://github.com/envato/unwrappr/pull/73
 [#74]: https://github.com/envato/unwrappr/pull/74
+[#75]: https://github.com/envato/unwrappr/pull/75
 
 ## [0.3.5] 2019-11-28
 ### Changed

--- a/lib/unwrappr/researchers/github_repo.rb
+++ b/lib/unwrappr/researchers/github_repo.rb
@@ -7,7 +7,10 @@ module Unwrappr
     # Implements the `gem_researcher` interface required by the
     # LockFileAnnotator.
     class GithubRepo
-      GITHUB_URI_PATTERN = %r{^https?://github.com/(?<repo>[^/]+/[[:alnum:]_.-]+)}i.freeze
+      GITHUB_URI_PATTERN = %r{^https?://
+                              github.com/
+                              (?<repo>[^/]+/[[:alnum:]_.-]+)
+                              }ix.freeze
 
       def research(_gem_change, gem_change_info)
         repo = match_repo(gem_change_info, :source_code_uri) ||

--- a/lib/unwrappr/researchers/github_repo.rb
+++ b/lib/unwrappr/researchers/github_repo.rb
@@ -7,7 +7,7 @@ module Unwrappr
     # Implements the `gem_researcher` interface required by the
     # LockFileAnnotator.
     class GithubRepo
-      GITHUB_URI_PATTERN = %r{^https?://github.com/(?<repo>[^/]+/[^/]+)}i.freeze
+      GITHUB_URI_PATTERN = %r{^https?://github.com/(?<repo>[^/]+/[[:alnum:]_.-]+)}i.freeze
 
       def research(_gem_change, gem_change_info)
         repo = match_repo(gem_change_info, :source_code_uri) ||

--- a/spec/lib/unwrappr/researchers/github_repo_spec.rb
+++ b/spec/lib/unwrappr/researchers/github_repo_spec.rb
@@ -17,7 +17,8 @@ module Unwrappr
           ['', 'https://github.com/envato/stack_master/tree', 'envato/stack_master'],
           [' ', 'https://github.com/envato/stack_master/tree', 'envato/stack_master'],
           ['https://bitbucket.org/envato/unwrappr/tree', 'https://github.com/envato/stack_master/tree', 'envato/stack_master'],
-          ['https://github.com/envato/unwrappr/tree', 'https://github.com/envato/stack_master/tree', 'envato/unwrappr']
+          ['https://github.com/envato/unwrappr/tree', 'https://github.com/envato/stack_master/tree', 'envato/unwrappr'],
+          [nil, 'https://github.com/rubymem/bundler-leak#readme', 'rubymem/bundler-leak'],
         ].each do |source_code_uri, homepage_uri, expected_repo|
           context "given source_code_uri: #{source_code_uri.inspect}, homepage_uri: #{homepage_uri.inspect}" do
             let(:gem_change_info) do

--- a/spec/lib/unwrappr/researchers/github_repo_spec.rb
+++ b/spec/lib/unwrappr/researchers/github_repo_spec.rb
@@ -18,7 +18,7 @@ module Unwrappr
           [' ', 'https://github.com/envato/stack_master/tree', 'envato/stack_master'],
           ['https://bitbucket.org/envato/unwrappr/tree', 'https://github.com/envato/stack_master/tree', 'envato/stack_master'],
           ['https://github.com/envato/unwrappr/tree', 'https://github.com/envato/stack_master/tree', 'envato/unwrappr'],
-          [nil, 'https://github.com/rubymem/bundler-leak#readme', 'rubymem/bundler-leak'],
+          [nil, 'https://github.com/rubymem/bundler-leak#readme', 'rubymem/bundler-leak']
         ].each do |source_code_uri, homepage_uri, expected_repo|
           context "given source_code_uri: #{source_code_uri.inspect}, homepage_uri: #{homepage_uri.inspect}" do
             let(:gem_change_info) do


### PR DESCRIPTION
#### Context

A recent run terminated with:

```
Octokit::InvalidRepository: "rubymem/bundler-leak#readme" is invalid as a repository identifier. Use the user/repo (String) format, or the repository ID (Integer), or a hash containing :repo and :user keys.
```

The repository name came from 
https://github.com/rubymem/bundler-leak/blob/master/gemspec.yml#L7

I could not find a repository name specification anywhere but playing with https://github.com/new revealed repository names are formed of alphanumeric characters, hyphens, underscores and full-stops.

#### Change

Update the `GITHUB_URI_PATTERN` to better handle such URIs.

#### Considerations

I considered using Ruby's `URI` module to extract the path but figured that was unnecessary at this juncture.
