### PR TITLE
Prepare to release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+[Unreleased]: https://github.com/envato/unwrappr/compare/v0.4.0...HEAD
+
+## [0.4.0] 2020-04-14
 ### Changed
 - `bundler-audit` limited to `>= 0.6.0` ([#71])
 
@@ -17,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for version numbers including a fourth segment (_e.g._ "6.0.2.2") ([#74])
 - Support for GitHub URIs including anchors ([#75])
 
-[Unreleased]: https://github.com/envato/unwrappr/compare/v0.3.5...HEAD
+[0.4.0]: https://github.com/envato/unwrappr/compare/v0.3.5..v0.4.0
 [#71]: https://github.com/envato/unwrappr/pull/71
 [#72]: https://github.com/envato/unwrappr/pull/72
 [#73]: https://github.com/envato/unwrappr/pull/73

--- a/lib/unwrappr/version.rb
+++ b/lib/unwrappr/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Unwrappr
-  VERSION = '0.3.5'
+  VERSION = '0.4.0'
 end


### PR DESCRIPTION
#### Context

 - #71 (@orien)
 - #72 (@dferdian)
 - #73 (@johnsyweb)
 - #74 (@johnsyweb)
 - #75 (@johnsyweb)

...are all unreleased. Time to send them off to Rubygems!

#### Change

Updated minor version since this is still considered pre-release but Ruby versions are now unsupported.