### PR TITLE
CI via GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: [2.5, 2.6, 2.7]
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+    - name: Install dependencies
+      run: bundle install
+    - name: Run tests
+      run: bundle exec rake

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,8 +1,9 @@
 ---
 AllCops:
-  TargetRubyVersion: 2.5
   Exclude:
     - 'spike/*.rb'
+  NewCops: enable
+  TargetRubyVersion: 2.5
 
 Gemspec/RequiredRubyVersion:
   Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-sudo: false
-language: ruby
-rvm:
-  - 2.5.8
-  - 2.6.6
-  - 2.7.1
-before_install:
-  - gem update --system

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Fixed homepage URL in gemspec ([#77])
+
 [Unreleased]: https://github.com/envato/unwrappr/compare/v0.4.0...HEAD
+[#77]: https://github.com/envato/unwrappr/pull/77
 
 ## [0.4.0] 2020-04-14
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- Moved CI to GitHub Actions ([#78])
 - Fixed homepage URL in gemspec ([#77])
 
 [Unreleased]: https://github.com/envato/unwrappr/compare/v0.4.0...HEAD
 [#77]: https://github.com/envato/unwrappr/pull/77
+[#78]: https://github.com/envato/unwrappr/pull/78
 
 ## [0.4.0] 2020-04-14
 ### Changed

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ to get regular dependency updates into production.
   - Vulnerability advisory information using [bundler-audit](https://github.com/rubysec/bundler-audit)
   - Links to the home page, source code and change log (where available) of each gem
 
-## Development status [![CI Status](https://github.com/envato/unwrappr/workflows/ci/badge.svg)](https://github.com/envato/unwrappr/actions)
+## Development status [![CI Status](https://github.com/envato/unwrappr/workflows/CI/badge.svg)](https://github.com/envato/unwrappr/actions?query=workflow%3ACI)
 
 `unwrappr` is used in many projects around [Envato][envato]
 However, it is still undergoing development and features are likely to change

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ to get regular dependency updates into production.
   - Vulnerability advisory information using [bundler-audit](https://github.com/rubysec/bundler-audit)
   - Links to the home page, source code and change log (where available) of each gem
 
-## Development status [![Build Status](https://travis-ci.org/envato/unwrappr.svg?branch=master)](https://travis-ci.org/envato/unwrappr)
+## Development status [![CI Status](https://github.com/envato/unwrappr/workflows/ci/badge.svg)](https://github.com/envato/unwrappr/actions)
 
 `unwrappr` is used in many projects around [Envato][envato]
 However, it is still undergoing development and features are likely to change

--- a/lib/unwrappr/gem_change.rb
+++ b/lib/unwrappr/gem_change.rb
@@ -18,6 +18,7 @@ module Unwrappr
     end
 
     attr_reader :name, :head_version, :base_version, :line_number
+
     def_delegators :@lock_file_diff, :filename, :sha
 
     def added?

--- a/lib/unwrappr/git_command_runner.rb
+++ b/lib/unwrappr/git_command_runner.rb
@@ -80,7 +80,7 @@ module Unwrappr
 
       def log_options
         {}.tap do |opt|
-          opt[:log] = Logger.new(STDOUT) if ENV['DEBUG']
+          opt[:log] = Logger.new($stdout) if ENV['DEBUG']
         end
       end
 

--- a/lib/unwrappr/lock_file_diff.rb
+++ b/lib/unwrappr/lock_file_diff.rb
@@ -63,7 +63,7 @@ module Unwrappr
       # '+    websocket-driver (0.6.5)'
       # Careful not to match this (note the wider indent):
       # '+      websocket-extensions (>= 0.1.0)'
-      pattern = /^(?<change_type>[\+\-])    (?<gem_name>[\S]+) \(\d/
+      pattern = /^(?<change_type>[+\-])    (?<gem_name>\S+) \(\d/
       match = pattern.match(line)
       return match[:gem_name], match[:change_type] unless match.nil?
     end

--- a/spec/lib/unwrappr/ruby_gems_spec.rb
+++ b/spec/lib/unwrappr/ruby_gems_spec.rb
@@ -41,14 +41,12 @@ module Unwrappr
     end
 
     context 'runtime error' do
-      class UnknownError < StandardError; end
-
       before do
-        allow(Faraday).to receive(:get).and_raise(UnknownError)
+        allow(Faraday).to receive(:get).and_raise(StandardError)
       end
 
-      it 'returns nil' do
-        expect { subject }.to raise_error(instance_of(UnknownError))
+      it 'is re-raised' do
+        expect { subject }.to raise_error(instance_of(StandardError))
       end
     end
   end


### PR DESCRIPTION
#### Context

With wait times getting longer on our previous CI provider, we have decided to use GitHub Actions for our open-source projects.

#### Change

 - Defined CI/Test action in .github/workflows/ci.yml
 - Addressed stylistic issues with Rubocop