### PR TITLE
Allow Specification of Base Branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Add
 - Support for Ruby 3. ([#79])
+- Allow specification of base branch, upone which to base the pull-request
+  ([#80])
 
 ### Changed
 - Moved CI to GitHub Actions ([#78])
@@ -17,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#77]: https://github.com/envato/unwrappr/pull/77
 [#78]: https://github.com/envato/unwrappr/pull/78
 [#79]: https://github.com/envato/unwrappr/pull/79
+[#80]: https://github.com/envato/unwrappr/pull/80
 
 ## [0.4.0] 2020-04-14
 ### Changed

--- a/lib/unwrappr/git_command_runner.rb
+++ b/lib/unwrappr/git_command_runner.rb
@@ -7,9 +7,9 @@ module Unwrappr
   # Runs Git commands
   module GitCommandRunner
     class << self
-      def create_branch!
+      def create_branch!(base_branch:)
         raise 'Not a git working dir' unless git_dir?
-        raise 'failed to create branch' unless branch_created?
+        raise "failed to create branch from '#{base_branch}'" unless branch_created?(base_branch: base_branch)
       end
 
       def commit_and_push_changes!
@@ -50,10 +50,10 @@ module Unwrappr
         git_wrap { !current_branch_name.empty? }
       end
 
-      def branch_created?
+      def branch_created?(base_branch:)
         timestamp = Time.now.strftime('%Y%m%d-%H%M').freeze
         git_wrap do
-          git.checkout('origin/master')
+          git.checkout(base_branch) unless base_branch.nil?
           git.branch("auto_bundle_update_#{timestamp}").checkout
         end
       end


### PR DESCRIPTION
#### Context

There are two reasons for this PR.

1. It is becoming more common for the default branch of a repository to be named 'main'. 
1. https://github.com/sobanakram/unwrappr/commit/b8bea1d204c524f3a39cd98bc02ebf3cd3f876c9 shows that the current branch is likely to be a preference for the base branch.

#### Change

Add a base branch option to all commands and only check out that branch if it's specified.

#### Considerations

This is a change of behaviour but since this is a pre-release, I think that's OK.