### PR TITLE
Prepare for renaming default branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Moved CI to GitHub Actions ([#78])
 - Fixed homepage URL in gemspec ([#77])
+- Default branch is now `main`([#81])
 
 [Unreleased]: https://github.com/envato/unwrappr/compare/v0.4.0...HEAD
 [#77]: https://github.com/envato/unwrappr/pull/77
 [#78]: https://github.com/envato/unwrappr/pull/78
 [#79]: https://github.com/envato/unwrappr/pull/79
+[#81]: https://github.com/envato/unwrappr/pull/81
 
 ## [0.4.0] 2020-04-14
 ### Changed

--- a/README.md
+++ b/README.md
@@ -85,16 +85,16 @@ See https://github.com/settings/tokens to set up personal access tokens.
  - [Em Esc](https://github.com/emesc)
  - [Chun-wei Kuo](https://github.com/Domon)
 
-## License [![license](https://img.shields.io/github/license/mashape/apistatus.svg?style=flat-square)](https://github.com/envato/unwrappr/blob/master/LICENSE.txt)
+## License [![license](https://img.shields.io/github/license/mashape/apistatus.svg?style=flat-square)](https://github.com/envato/unwrappr/blob/HEAD/LICENSE.txt)
 
 `unwrappr` uses MIT license. See
-[`LICENSE.txt`](https://github.com/envato/unwrappr/blob/master/LICENSE.txt) for
+[`LICENSE.txt`](https://github.com/envato/unwrappr/blob/HEAD/LICENSE.txt) for
 details.
 
 ## Code of Conduct
 
 We welcome contribution from everyone. Read more about it in
-[`CODE_OF_CONDUCT.md`](https://github.com/envato/unwrappr/blob/master/CODE_OF_CONDUCT.md)
+[`CODE_OF_CONDUCT.md`](https://github.com/envato/unwrappr/blob/HEAD/CODE_OF_CONDUCT.md)
 
 ## Contributing [![PRs welcome](https://img.shields.io/badge/PRs-welcome-orange.svg?style=flat-square)](https://github.com/envato/unwrappr/issues)
 

--- a/unwrappr.gemspec
+++ b/unwrappr.gemspec
@@ -53,8 +53,8 @@ Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength:
 
   spec.metadata = {
     'bug_tracker_uri' => "#{GITHUB_URL}/issues",
-    'changelog_uri' => "#{GITHUB_URL}/blob/master/CHANGELOG.md",
-    'documentation_uri' => "#{GITHUB_URL}/blob/master/README.md",
+    'changelog_uri' => "#{GITHUB_URL}/blob/HEAD/CHANGELOG.md",
+    'documentation_uri' => "#{GITHUB_URL}/blob/HEAD/README.md",
     'homepage_uri' => HOMEPAGE_URL,
     'source_code_uri' => GITHUB_URL
   }


### PR DESCRIPTION
#### Context

As alluded to in #80, it's more inclusive to name the [Git default branch as `main`](https://www.hanselman.com/blog/easily-rename-your-git-default-branch-from-master-to-main)/), so let's do that.

#### Change

Use HEAD commit on default branch for URIs

#### Considerations

There's probably enough in the Changelog to warrant a v0.5.0 release now.