### PR TITLE
Rename methods with side effects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Moved CI to GitHub Actions ([#78])
 - Fixed homepage URL in gemspec ([#77])
 - Default branch is now `main`([#81])
+- Rename private predicate methods in GitCommandRunner to be more descriptive.
+  ([#82])
 
 [Unreleased]: https://github.com/envato/unwrappr/compare/v0.4.0...HEAD
 [#77]: https://github.com/envato/unwrappr/pull/77
@@ -22,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#79]: https://github.com/envato/unwrappr/pull/79
 [#80]: https://github.com/envato/unwrappr/pull/80
 [#81]: https://github.com/envato/unwrappr/pull/81
+[#82]: https://github.com/envato/unwrappr/pull/82
 
 ## [0.4.0] 2020-04-14
 ### Changed

--- a/lib/unwrappr/git_command_runner.rb
+++ b/lib/unwrappr/git_command_runner.rb
@@ -15,7 +15,7 @@ module Unwrappr
       def commit_and_push_changes!
         raise 'failed to add git changes' unless stage_all_changes
         raise 'failed to commit changes' unless commit_staged_changes
-        raise 'failed to push changes' unless git_pushed?
+        raise 'failed to push changes' unless push_current_branch_to_origin
       end
 
       def reset_client
@@ -66,7 +66,7 @@ module Unwrappr
         git_wrap { git.commit('Automatic Bundle Update') }
       end
 
-      def git_pushed?
+      def push_current_branch_to_origin
         git_wrap { git.push('origin', current_branch_name) }
       end
 

--- a/lib/unwrappr/git_command_runner.rb
+++ b/lib/unwrappr/git_command_runner.rb
@@ -14,7 +14,7 @@ module Unwrappr
 
       def commit_and_push_changes!
         raise 'failed to add git changes' unless stage_all_changes
-        raise 'failed to commit changes' unless git_committed?
+        raise 'failed to commit changes' unless commit_staged_changes
         raise 'failed to push changes' unless git_pushed?
       end
 
@@ -62,7 +62,7 @@ module Unwrappr
         git_wrap { git.add(all: true) }
       end
 
-      def git_committed?
+      def commit_staged_changes
         git_wrap { git.commit('Automatic Bundle Update') }
       end
 

--- a/lib/unwrappr/git_command_runner.rb
+++ b/lib/unwrappr/git_command_runner.rb
@@ -9,7 +9,7 @@ module Unwrappr
     class << self
       def create_branch!(base_branch:)
         raise 'Not a git working dir' unless git_dir?
-        raise "failed to create branch from '#{base_branch}'" unless branch_created?(base_branch: base_branch)
+        raise "failed to create branch from '#{base_branch}'" unless checkout_target_branch(base_branch: base_branch)
       end
 
       def commit_and_push_changes!
@@ -50,7 +50,7 @@ module Unwrappr
         git_wrap { !current_branch_name.empty? }
       end
 
-      def branch_created?(base_branch:)
+      def checkout_target_branch(base_branch:)
         timestamp = Time.now.strftime('%Y%m%d-%H%M').freeze
         git_wrap do
           git.checkout(base_branch) unless base_branch.nil?

--- a/lib/unwrappr/git_command_runner.rb
+++ b/lib/unwrappr/git_command_runner.rb
@@ -13,7 +13,7 @@ module Unwrappr
       end
 
       def commit_and_push_changes!
-        raise 'failed to add git changes' unless git_added_changes?
+        raise 'failed to add git changes' unless stage_all_changes
         raise 'failed to commit changes' unless git_committed?
         raise 'failed to push changes' unless git_pushed?
       end
@@ -58,7 +58,7 @@ module Unwrappr
         end
       end
 
-      def git_added_changes?
+      def stage_all_changes
         git_wrap { git.add(all: true) }
       end
 


### PR DESCRIPTION
#### Context

[It is surprising to find private predicate methods with side-effects](https://github.com/envato/unwrappr/pull/80#discussion_r549190831).

#### Change

Rename private predicate methods in GitCommandRunner to be more descriptive.

