### PR TITLE
Create PR against Default Branch

### DIFF
--- a/lib/unwrappr/github/client.rb
+++ b/lib/unwrappr/github/client.rb
@@ -30,12 +30,17 @@ module Unwrappr
         def create_and_annotate_pull_request
           pr = git_client.create_pull_request(
             repo_name_and_org,
-            'master',
+            repo_default_branch,
             Unwrappr::GitCommandRunner.current_branch_name,
             'Automated Bundle Update',
             pull_request_body
           )
           annotate_pull_request(pr.number)
+        end
+
+        def repo_default_branch
+          git_client.repository(repo_name_and_org)
+                    .default_branch
         end
 
         def pull_request_body
@@ -58,16 +63,16 @@ module Unwrappr
         end
 
         def github_token
-          @github_token ||= ENV.fetch('GITHUB_TOKEN') do
-            raise %(
+          @github_token ||= ENV.fetch('GITHUB_TOKEN')
+        rescue KeyError
+          raise %(
 Missing environment variable GITHUB_TOKEN.
 See https://github.com/settings/tokens to set up personal access tokens.
 Add to the environment:
 
     export GITHUB_TOKEN=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-)
-          end
+            )
         end
       end
     end

--- a/spec/lib/unwrappr/github/client_spec.rb
+++ b/spec/lib/unwrappr/github/client_spec.rb
@@ -3,9 +3,7 @@
 require 'spec_helper'
 
 RSpec.describe Unwrappr::GitHub::Client do
-  before do
-    described_class.reset_client
-  end
+  before { described_class.reset_client }
 
   describe '#make_pull_request!' do
     subject(:make_pull_request!) { described_class.make_pull_request! }
@@ -22,6 +20,7 @@ RSpec.describe Unwrappr::GitHub::Client do
     context 'with a token' do
       before do
         allow(ENV).to receive(:fetch).with('GITHUB_TOKEN').and_return('fake tokenz r us')
+        allow(octokit_client).to receive_message_chain('repository.default_branch').and_return('main')
       end
 
       context 'Given a successful Octokit pull request is created' do
@@ -64,9 +63,9 @@ RSpec.describe Unwrappr::GitHub::Client do
         end
       end
 
-      context 'Given an exception is raised from octokit' do
+      context 'Given an exception is raised from Octokit' do
         before do
-          expect(octokit_client).to receive(:create_pull_request)
+          expect(octokit_client).to receive(:repository)
             .and_raise(Octokit::ClientError)
         end
 
@@ -79,7 +78,9 @@ RSpec.describe Unwrappr::GitHub::Client do
 
     context 'without a token' do
       before do
-        allow(ENV).to receive(:[]).with('GITHUB_TOKEN').and_return(nil)
+        expect(ENV).to receive(:fetch)
+          .with('GITHUB_TOKEN')
+          .and_raise(KeyError, 'key not found GITHUB_TOKEN')
       end
 
       it 'provides useful feedback' do


### PR DESCRIPTION
#### Context

Testing #83 locally, I discovered that if the default branch was renamed from `master` to `main`, PRs raised against `master` would succeed but if a repository has only ever had a `main` branch, it would fail.

#### Change

Get the default branch from GitHub's API and fix up the specs.