### PR TITLE
Upgrade Faraday dependency to version 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Default branch is now `main`([#81])
 - Rename private predicate methods in GitCommandRunner to be more descriptive.
   ([#82])
+- Upgrade Faraday dependency to version 1 ([#85])
 
 [Unreleased]: https://github.com/envato/unwrappr/compare/v0.4.0...HEAD
 [#77]: https://github.com/envato/unwrappr/pull/77
@@ -25,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#80]: https://github.com/envato/unwrappr/pull/80
 [#81]: https://github.com/envato/unwrappr/pull/81
 [#82]: https://github.com/envato/unwrappr/pull/82
+[#85]: https://github.com/envato/unwrappr/pull/85
 
 ## [0.4.0] 2020-04-14
 ### Changed

--- a/unwrappr.gemspec
+++ b/unwrappr.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength:
   spec.add_dependency 'bundler', '< 3'
   spec.add_dependency 'bundler-audit', '>= 0.6.0'
   spec.add_dependency 'clamp', '~> 1'
-  spec.add_dependency 'faraday', '~> 0'
+  spec.add_dependency 'faraday', '~> 1'
   spec.add_dependency 'git', '~> 1'
   spec.add_dependency 'octokit', '~> 4.0'
   spec.add_dependency 'safe_shell', '~> 1'


### PR DESCRIPTION
https://rubygems.org/gems/faraday

Faraday is used by the Octokit gem and directly by Unwrappr in one spot (which works fine on version 1).

https://github.com/envato/unwrappr/blob/e1736ef61e7139c2810e1929efe481d5d0fc242f/lib/unwrappr/ruby_gems.rb#L13