### PR TITLE
Add support for annotating multiple gem lock files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-[Unreleased]: https://github.com/envato/unwrappr/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/envato/unwrappr/compare/v0.6.0...HEAD
+
+## [0.6.0] 2021-05-12
+
+### Add
+- Allow specification of Gemfile lock files to annotate. ([#80])
 
 ## [0.5.0] 2021-01-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.6.0] 2021-05-12
 
 ### Add
-- Allow specification of Gemfile lock files to annotate. ([#80])
+- Allow specification of Gemfile lock files to annotate. ([#86])
+
+[0.6.0]: https://github.com/envato/unwrappr/compare/v0.5.0..v0.6.0
+[#86]: https://github.com/envato/unwrappr/pull/86
 
 ## [0.5.0] 2021-01-04
 

--- a/lib/unwrappr/cli.rb
+++ b/lib/unwrappr/cli.rb
@@ -21,7 +21,7 @@ module Unwrappr
            'LOCK_FILE',
            'The Gemfile.lock files to annotate. Useful when working with multiple lock files.',
            multivalued: true,
-           default: 'Gemfile.lock',
+           default: ['Gemfile.lock'],
            attribute_name: :lock_files
 
     option ['-v', '--version'], :flag, 'Show version' do

--- a/lib/unwrappr/cli.rb
+++ b/lib/unwrappr/cli.rb
@@ -83,7 +83,7 @@ module Unwrappr
   end
 
   def self.run_unwapper_in_pwd(base_branch:, lock_files:)
-    return unless lockfiles_present?(lock_files)
+    return unless any_lockfile_present?(lock_files)
 
     puts "Doing the unwrappr thing in #{Dir.pwd}"
 
@@ -93,7 +93,7 @@ module Unwrappr
     GitHub::Client.make_pull_request!(lock_files)
   end
 
-  def self.lockfiles_present?(lock_files)
-    lock_files.all? { |lock_file| GitCommandRunner.file_exist?(lock_file) }
+  def self.any_lockfile_present?(lock_files)
+    lock_files.any? { |lock_file| GitCommandRunner.file_exist?(lock_file) }
   end
 end

--- a/lib/unwrappr/cli.rb
+++ b/lib/unwrappr/cli.rb
@@ -17,6 +17,13 @@ module Unwrappr
            DESCRIPTION
            attribute_name: :base_branch)
 
+    option ['-f', '--lock-file'],
+           'LOCK_FILE',
+           'The Gemfile.lock files to annotate. Useful when working with multiple lock files.',
+           multivalued: true,
+           default: 'Gemfile.lock',
+           attribute_name: :lock_files
+
     option ['-v', '--version'], :flag, 'Show version' do
       puts "unwrappr v#{Unwrappr::VERSION}"
       exit(0)
@@ -25,7 +32,7 @@ module Unwrappr
     subcommand 'all', 'run bundle update, push to github, '\
                       'create a pr and annotate changes' do
       def execute
-        Unwrappr.run_unwapper_in_pwd(base_branch: base_branch)
+        Unwrappr.run_unwapper_in_pwd(base_branch: base_branch, lock_files: lock_files)
       end
     end
 
@@ -42,7 +49,8 @@ module Unwrappr
       def execute
         LockFileAnnotator.annotate_github_pull_request(
           repo: repo,
-          pr_number: pr.to_i
+          pr_number: pr.to_i,
+          lock_files: lock_files
         )
       end
     end
@@ -68,24 +76,24 @@ module Unwrappr
             )
           end
 
-          Dir.chdir(repo) { Unwrappr.run_unwapper_in_pwd(base_branch: base_branch) }
+          Dir.chdir(repo) { Unwrappr.run_unwapper_in_pwd(base_branch: base_branch, lock_files: lock_files) }
         end
       end
     end
   end
 
-  def self.run_unwapper_in_pwd(base_branch:)
-    return unless lockfile_present?
+  def self.run_unwapper_in_pwd(base_branch:, lock_files:)
+    return unless lockfiles_present?(lock_files)
 
     puts "Doing the unwrappr thing in #{Dir.pwd}"
 
     GitCommandRunner.create_branch!(base_branch: base_branch)
     BundlerCommandRunner.bundle_update!
     GitCommandRunner.commit_and_push_changes!
-    GitHub::Client.make_pull_request!
+    GitHub::Client.make_pull_request!(lock_files)
   end
 
-  def self.lockfile_present?
-    GitCommandRunner.file_exist?('Gemfile.lock')
+  def self.lockfiles_present?(lock_files)
+    lock_files.all? { |lock_file| GitCommandRunner.file_exist?(lock_file) }
   end
 end

--- a/lib/unwrappr/cli.rb
+++ b/lib/unwrappr/cli.rb
@@ -18,7 +18,7 @@ module Unwrappr
            attribute_name: :base_branch)
 
     option ['-f', '--lock-file'],
-           'LOCK_FILE',
+           'LOCK_FILE1 [-f LOCK_FILE2] [-f LOCK_FILE3] [-f ...]',
            'The Gemfile.lock files to annotate. Useful when working with multiple lock files.',
            multivalued: true,
            default: ['Gemfile.lock'],

--- a/lib/unwrappr/github/client.rb
+++ b/lib/unwrappr/github/client.rb
@@ -12,8 +12,8 @@ module Unwrappr
           @github_token = nil
         end
 
-        def make_pull_request!
-          create_and_annotate_pull_request
+        def make_pull_request!(lock_files)
+          create_and_annotate_pull_request(lock_files)
         rescue Octokit::ClientError => e
           raise "Failed to create and annotate pull request: #{e}"
         end
@@ -27,7 +27,7 @@ module Unwrappr
           [m[:org], m[:repo]].join('/')
         end
 
-        def create_and_annotate_pull_request
+        def create_and_annotate_pull_request(lock_files)
           pr = git_client.create_pull_request(
             repo_name_and_org,
             repo_default_branch,
@@ -35,7 +35,7 @@ module Unwrappr
             'Automated Bundle Update',
             pull_request_body
           )
-          annotate_pull_request(pr.number)
+          annotate_pull_request(pr.number, lock_files)
         end
 
         def repo_default_branch
@@ -50,10 +50,11 @@ module Unwrappr
           BODY
         end
 
-        def annotate_pull_request(pr_number)
+        def annotate_pull_request(pr_number, lock_files)
           LockFileAnnotator.annotate_github_pull_request(
             repo: repo_name_and_org,
             pr_number: pr_number,
+            lock_files: lock_files,
             client: git_client
           )
         end

--- a/lib/unwrappr/github/pr_source.rb
+++ b/lib/unwrappr/github/pr_source.rb
@@ -9,9 +9,10 @@ module Unwrappr
     # Implements the `lock_file_diff_source` interface as defined by the
     # LockFileAnnotator.
     class PrSource
-      def initialize(repo, pr_number, client)
+      def initialize(repo, pr_number, lock_files, client)
         @repo = repo
         @pr_number = pr_number
+        @lock_files = lock_files
         @client = client
       end
 
@@ -33,7 +34,7 @@ module Unwrappr
         @lock_file_diffs ||= @client
                              .pull_request_files(@repo, @pr_number)
                              .select do |file|
-                               File.basename(file.filename) == 'Gemfile.lock'
+                               @lock_files.include?(File.basename(file.filename))
                              end
       end
 

--- a/lib/unwrappr/lock_file_annotator.rb
+++ b/lib/unwrappr/lock_file_annotator.rb
@@ -54,6 +54,8 @@ module Unwrappr
 
     def annotate
       @lock_file_diff_source.each_file do |lock_file_diff|
+        puts "Annotating #{lock_file_diff.filename}"
+
         lock_file_diff.each_gem_change do |gem_change|
           gem_change_info = @gem_researcher.research(gem_change, {})
           message = @annotation_writer.write(gem_change, gem_change_info)

--- a/lib/unwrappr/lock_file_annotator.rb
+++ b/lib/unwrappr/lock_file_annotator.rb
@@ -18,10 +18,10 @@ module Unwrappr
   class LockFileAnnotator
     # rubocop:disable Metrics/MethodLength
     def self.annotate_github_pull_request(
-      repo:, pr_number:, client: Octokit.client
+      repo:, pr_number:, lock_files:, client: Octokit.client
     )
       new(
-        lock_file_diff_source: Github::PrSource.new(repo, pr_number, client),
+        lock_file_diff_source: Github::PrSource.new(repo, pr_number, lock_files, client),
         annotation_sink: Github::PrSink.new(repo, pr_number, client),
         annotation_writer: Writers::Composite.new(
           Writers::Title,

--- a/lib/unwrappr/lock_file_comparator.rb
+++ b/lib/unwrappr/lock_file_comparator.rb
@@ -21,7 +21,9 @@ module Unwrappr
       private
 
       def specs_versions(lock_file)
-        Hash[lock_file.specs.map { |s| [s.name.to_sym, s.version.to_s] }]
+        lock_file.specs.each_with_object({}) do |s, memo|
+          memo[s.name.to_sym] = s.version.to_s
+        end
       end
     end
   end

--- a/spec/lib/unwrappr/github/client_spec.rb
+++ b/spec/lib/unwrappr/github/client_spec.rb
@@ -75,8 +75,8 @@ RSpec.describe Unwrappr::GitHub::Client do
 
             expect(Unwrappr::LockFileAnnotator)
               .to have_received(:annotate_github_pull_request)
-                    .with(repo: 'org/repo', pr_number: 34, lock_files: ['Gemfile.lock', 'Gemfile_next.lock'],
-                          client: octokit_client)
+              .with(repo: 'org/repo', pr_number: 34, lock_files: ['Gemfile.lock', 'Gemfile_next.lock'],
+                    client: octokit_client)
           end
         end
       end

--- a/spec/lib/unwrappr/github/client_spec.rb
+++ b/spec/lib/unwrappr/github/client_spec.rb
@@ -3,10 +3,12 @@
 require 'spec_helper'
 
 RSpec.describe Unwrappr::GitHub::Client do
+  let(:lock_files) { ['Gemfile.lock'] }
+
   before { described_class.reset_client }
 
   describe '#make_pull_request!' do
-    subject(:make_pull_request!) { described_class.make_pull_request! }
+    subject(:make_pull_request!) { described_class.make_pull_request!(lock_files) }
 
     let(:git_url) { 'https://github.com/org/repo.git' }
     let(:octokit_client) { instance_spy(Octokit::Client, :fake_octokit, pull_request_files: []) }
@@ -44,7 +46,7 @@ RSpec.describe Unwrappr::GitHub::Client do
 
             expect(Unwrappr::LockFileAnnotator)
               .to have_received(:annotate_github_pull_request)
-              .with(repo: 'org/repo', pr_number: 34, client: octokit_client)
+              .with(repo: 'org/repo', pr_number: 34, lock_files: ['Gemfile.lock'], client: octokit_client)
           end
         end
 
@@ -58,7 +60,23 @@ RSpec.describe Unwrappr::GitHub::Client do
 
             expect(Unwrappr::LockFileAnnotator)
               .to have_received(:annotate_github_pull_request)
-              .with(repo: 'org/repo', pr_number: 34, client: octokit_client)
+              .with(repo: 'org/repo', pr_number: 34, lock_files: ['Gemfile.lock'], client: octokit_client)
+          end
+        end
+
+        context 'When multiple lock files are specified' do
+          let(:lock_files) { ['Gemfile.lock', 'Gemfile_next.lock'] }
+          let(:git_url) { 'https://github.com/org/repo' }
+
+          it 'annotates the pull request' do
+            allow(Unwrappr::LockFileAnnotator).to receive(:annotate_github_pull_request)
+
+            make_pull_request!
+
+            expect(Unwrappr::LockFileAnnotator)
+              .to have_received(:annotate_github_pull_request)
+                    .with(repo: 'org/repo', pr_number: 34, lock_files: ['Gemfile.lock', 'Gemfile_next.lock'],
+                          client: octokit_client)
           end
         end
       end

--- a/spec/lib/unwrappr/github/pr_source_spec.rb
+++ b/spec/lib/unwrappr/github/pr_source_spec.rb
@@ -17,7 +17,6 @@ module Unwrappr
     let(:pr) { double }
     let(:content1) { double(content: 'encoded-content-1') }
     let(:content2) { double(content: 'encoded-content-2') }
-    let(:lock_file_diff) { double }
 
     before do
       allow(LockFileDiff).to receive(:new)

--- a/spec/lib/unwrappr/github/pr_source_spec.rb
+++ b/spec/lib/unwrappr/github/pr_source_spec.rb
@@ -2,10 +2,11 @@
 
 module Unwrappr
   RSpec.describe Github::PrSource do
-    subject(:pr_source) { Github::PrSource.new(repo, pr_number, client) }
+    subject(:pr_source) { Github::PrSource.new(repo, pr_number, lock_files, client) }
 
     let(:repo) { 'envato/unwrappr' }
     let(:pr_number) { 223 }
+    let(:lock_files) { ['Gemfile.lock'] }
     let(:client) { instance_double(Octokit::Client) }
     let(:pr_files) do
       [
@@ -19,7 +20,9 @@ module Unwrappr
     let(:lock_file_diff) { double }
 
     before do
-      allow(LockFileDiff).to receive(:new).and_return(lock_file_diff)
+      allow(LockFileDiff).to receive(:new)
+                               .with(hash_including(filename: 'my/Gemfile.lock'))
+                               .and_return(double(filename: 'my/Gemfile.lock'))
       allow(Base64).to receive(:decode64)
         .with('encoded-content-1')
         .and_return('content-1')
@@ -54,7 +57,7 @@ module Unwrappr
       end
 
       it 'identifies the Gemfile.lock' do
-        expect(files).to eq([lock_file_diff])
+        expect(files.map(&:filename)).to eq(['my/Gemfile.lock'])
       end
 
       it 'produces a LockFileDiff with the expected attributes' do
@@ -65,6 +68,49 @@ module Unwrappr
                 head_file: 'content-2',
                 patch: 'my-gem-patch',
                 sha: 'head-sha')
+      end
+
+      context 'when multiple gem lock files are specified' do
+        let(:lock_files) { ['Gemfile.lock', 'Gemfile_next.lock'] }
+        let(:pr_files) do
+          [
+            double(filename: 'my/Gemfile.lock', patch: 'my-gem-patch'),
+            double(filename: 'Gemfile_next.lock', patch: 'next-gem-patch'),
+            double(filename: 'not.a.gem.file.lock', patch: 'another-patch')
+          ]
+        end
+
+        before do
+          allow(LockFileDiff).to receive(:new)
+                                   .with(hash_including(filename: 'Gemfile_next.lock'))
+                                   .and_return(double(filename: 'Gemfile_next.lock'))
+          allow(client).to receive(:contents)
+                             .with(repo, path: 'Gemfile_next.lock', ref: 'base-sha')
+                             .and_return(content1)
+          allow(client).to receive(:contents)
+                             .with(repo, path: 'Gemfile_next.lock', ref: 'head-sha')
+                             .and_return(content2)
+        end
+
+        it 'identifies all the gem lock files' do
+          expect(files.map(&:filename)).to eq(['my/Gemfile.lock', 'Gemfile_next.lock'])
+        end
+
+        it 'produces LockFileDiff instances with the expected attributes' do
+          files
+          expect(LockFileDiff).to have_received(:new)
+                                    .with(filename: 'my/Gemfile.lock',
+                                          base_file: 'content-1',
+                                          head_file: 'content-2',
+                                          patch: 'my-gem-patch',
+                                          sha: 'head-sha')
+          expect(LockFileDiff).to have_received(:new)
+                                    .with(filename: 'Gemfile_next.lock',
+                                          base_file: 'content-1',
+                                          head_file: 'content-2',
+                                          patch: 'next-gem-patch',
+                                          sha: 'head-sha')
+        end
       end
     end
   end

--- a/spec/lib/unwrappr/github/pr_source_spec.rb
+++ b/spec/lib/unwrappr/github/pr_source_spec.rb
@@ -21,8 +21,8 @@ module Unwrappr
 
     before do
       allow(LockFileDiff).to receive(:new)
-                               .with(hash_including(filename: 'my/Gemfile.lock'))
-                               .and_return(double(filename: 'my/Gemfile.lock'))
+        .with(hash_including(filename: 'my/Gemfile.lock'))
+        .and_return(double(filename: 'my/Gemfile.lock'))
       allow(Base64).to receive(:decode64)
         .with('encoded-content-1')
         .and_return('content-1')
@@ -82,14 +82,14 @@ module Unwrappr
 
         before do
           allow(LockFileDiff).to receive(:new)
-                                   .with(hash_including(filename: 'Gemfile_next.lock'))
-                                   .and_return(double(filename: 'Gemfile_next.lock'))
+            .with(hash_including(filename: 'Gemfile_next.lock'))
+            .and_return(double(filename: 'Gemfile_next.lock'))
           allow(client).to receive(:contents)
-                             .with(repo, path: 'Gemfile_next.lock', ref: 'base-sha')
-                             .and_return(content1)
+            .with(repo, path: 'Gemfile_next.lock', ref: 'base-sha')
+            .and_return(content1)
           allow(client).to receive(:contents)
-                             .with(repo, path: 'Gemfile_next.lock', ref: 'head-sha')
-                             .and_return(content2)
+            .with(repo, path: 'Gemfile_next.lock', ref: 'head-sha')
+            .and_return(content2)
         end
 
         it 'identifies all the gem lock files' do
@@ -99,17 +99,17 @@ module Unwrappr
         it 'produces LockFileDiff instances with the expected attributes' do
           files
           expect(LockFileDiff).to have_received(:new)
-                                    .with(filename: 'my/Gemfile.lock',
-                                          base_file: 'content-1',
-                                          head_file: 'content-2',
-                                          patch: 'my-gem-patch',
-                                          sha: 'head-sha')
+            .with(filename: 'my/Gemfile.lock',
+                  base_file: 'content-1',
+                  head_file: 'content-2',
+                  patch: 'my-gem-patch',
+                  sha: 'head-sha')
           expect(LockFileDiff).to have_received(:new)
-                                    .with(filename: 'Gemfile_next.lock',
-                                          base_file: 'content-1',
-                                          head_file: 'content-2',
-                                          patch: 'next-gem-patch',
-                                          sha: 'head-sha')
+            .with(filename: 'Gemfile_next.lock',
+                  base_file: 'content-1',
+                  head_file: 'content-2',
+                  patch: 'next-gem-patch',
+                  sha: 'head-sha')
         end
       end
     end


### PR DESCRIPTION
It's useful to be able annotate multiple Gemfile lock files in a single PR. It's especially useful when working with a dual booting system such as [bootboot](https://github.com/Shopify/bootboot).

This PR adds support for annotating multiple Gemfile lock files.