### PR TITLE
Prepare release v0.6.0

### DIFF
--- a/lib/unwrappr/version.rb
+++ b/lib/unwrappr/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Unwrappr
-  VERSION = '0.5.0'
+  VERSION = '0.6.0'
 end


### PR DESCRIPTION
#### Context

With the recent support for multiple gemfile lock files, it's time for a release so we can start using it!

#### Change

- Prepare 0.6.0 Release

#### Considerations

@johnsyweb, or another maintiner, can you please follow the instructions at https://github.com/envato/unwrappr#development-status- when you get a chance (unless I can release it?). 