### PR TITLE
Link to gem contents diff in gem change annotation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Add
+- Include link to gem contents diff in gem change annotation ([#88]).
+
 [Unreleased]: https://github.com/envato/unwrappr/compare/v0.6.0...HEAD
+[#88]: https://github.com/envato/unwrappr/pull/88
 
 ## [0.6.0] 2021-05-12
 

--- a/lib/unwrappr/writers/project_links.rb
+++ b/lib/unwrappr/writers/project_links.rb
@@ -37,7 +37,7 @@ module Unwrappr
       private_constant :GEM_DIFF_URL_TEMPLATE
 
       def gem_diff
-        unless ruby_gems_info.nil?
+        if !ruby_gems_info.nil? && !@gem_change.added? && !@gem_change.removed?
           gem_diff_url = format(GEM_DIFF_URL_TEMPLATE,
                                 @gem_change.name,
                                 @gem_change.base_version.to_s,

--- a/lib/unwrappr/writers/project_links.rb
+++ b/lib/unwrappr/writers/project_links.rb
@@ -18,19 +18,36 @@ module Unwrappr
       end
 
       def write
-        "[_#{change_log}, #{source_code}_]\n"
+        "[_#{change_log}, #{source_code}, #{gem_diff}_]\n"
       end
 
       private
 
       def change_log
         link_or_strikethrough('change-log',
-                              @gem_change_info[:ruby_gems]&.changelog_uri)
+                              ruby_gems_info&.changelog_uri)
       end
 
       def source_code
         link_or_strikethrough('source-code',
-                              @gem_change_info[:ruby_gems]&.source_code_uri)
+                              ruby_gems_info&.source_code_uri)
+      end
+
+      GEM_DIFF_URL_TEMPLATE = 'https://my.diffend.io/gems/%s/%s/%s'
+      private_constant :GEM_DIFF_URL_TEMPLATE
+
+      def gem_diff
+        unless ruby_gems_info.nil?
+          gem_diff_url = format(GEM_DIFF_URL_TEMPLATE,
+                                @gem_change.name,
+                                @gem_change.base_version.to_s,
+                                @gem_change.head_version.to_s)
+        end
+        link_or_strikethrough('gem-diff', gem_diff_url)
+      end
+
+      def ruby_gems_info
+        @gem_change_info[:ruby_gems]
       end
 
       def link_or_strikethrough(text, url)

--- a/spec/lib/unwrappr/lock_file_annotator_spec.rb
+++ b/spec/lib/unwrappr/lock_file_annotator_spec.rb
@@ -123,7 +123,7 @@ module Unwrappr
 
                 **Patch** version upgrade :chart_with_upwards_trend::small_blue_diamond: 3.7.0 → 3.7.1
 
-                [_[change-log](changelog-uri), [source-code](source-uri)_]
+                [_[change-log](changelog-uri), [source-code](source-uri), [gem-diff](https://my.diffend.io/gems/rspec-support/3.7.0/3.7.1)_]
               MESSAGE
             )
         end

--- a/spec/lib/unwrappr/writers/project_links_spec.rb
+++ b/spec/lib/unwrappr/writers/project_links_spec.rb
@@ -6,7 +6,15 @@ module Unwrappr
       describe '.write' do
         subject(:write) { ProjectLinks.write(gem_change, gem_change_info) }
 
-        let(:gem_change) { instance_double(GemChange) }
+        let(:gem_change) do
+          GemChange.new(
+            name: 'name',
+            base_version: GemVersion.new(1.0),
+            head_version: GemVersion.new(2.0),
+            line_number: nil,
+            lock_file_diff: nil
+          )
+        end
 
         context 'given gem change info with urls' do
           let(:gem_change_info) do
@@ -17,7 +25,7 @@ module Unwrappr
           end
 
           it { should eq <<~MESSAGE }
-            [_[change-log](changelog-uri), [source-code](source-uri)_]
+            [_[change-log](changelog-uri), [source-code](source-uri), [gem-diff](https://my.diffend.io/gems/name/1.0/2.0)_]
           MESSAGE
         end
 
@@ -30,7 +38,7 @@ module Unwrappr
           end
 
           it { is_expected.to eq <<~MESSAGE }
-            [_~~change-log~~, ~~source-code~~_]
+            [_~~change-log~~, ~~source-code~~, [gem-diff](https://my.diffend.io/gems/name/1.0/2.0)_]
           MESSAGE
         end
 
@@ -38,7 +46,7 @@ module Unwrappr
           let(:gem_change_info) { {} }
 
           it { should eq <<~MESSAGE }
-            [_~~change-log~~, ~~source-code~~_]
+            [_~~change-log~~, ~~source-code~~, ~~gem-diff~~_]
           MESSAGE
         end
       end

--- a/spec/lib/unwrappr/writers/project_links_spec.rb
+++ b/spec/lib/unwrappr/writers/project_links_spec.rb
@@ -9,12 +9,14 @@ module Unwrappr
         let(:gem_change) do
           GemChange.new(
             name: 'name',
-            base_version: GemVersion.new(1.0),
-            head_version: GemVersion.new(2.0),
+            base_version: base_version,
+            head_version: head_version,
             line_number: nil,
             lock_file_diff: nil
           )
         end
+        let(:base_version) { GemVersion.new('1.0') }
+        let(:head_version) { GemVersion.new('2.0') }
 
         context 'given gem change info with urls' do
           let(:gem_change_info) do
@@ -26,6 +28,34 @@ module Unwrappr
 
           it { should eq <<~MESSAGE }
             [_[change-log](changelog-uri), [source-code](source-uri), [gem-diff](https://my.diffend.io/gems/name/1.0/2.0)_]
+          MESSAGE
+        end
+
+        context 'given gem change info with urls for an added gem' do
+          let(:gem_change_info) do
+            {
+              ruby_gems: spy(source_code_uri: 'source-uri',
+                             changelog_uri: 'changelog-uri')
+            }
+          end
+          let(:base_version) { nil }
+
+          it { should eq <<~MESSAGE }
+            [_[change-log](changelog-uri), [source-code](source-uri), ~~gem-diff~~_]
+          MESSAGE
+        end
+
+        context 'given gem change info with urls for a removed gem' do
+          let(:gem_change_info) do
+            {
+              ruby_gems: spy(source_code_uri: 'source-uri',
+                             changelog_uri: 'changelog-uri')
+            }
+          end
+          let(:head_version) { nil }
+
+          it { should eq <<~MESSAGE }
+            [_[change-log](changelog-uri), [source-code](source-uri), ~~gem-diff~~_]
           MESSAGE
         end
 


### PR DESCRIPTION
I see Diffend provides a [nice diff of gem contents](https://my.diffend.io/gems/unwrappr/0.5.0/0.6.0) on rubygems.org. It'd be handy to include a link to this diff in the gem change annotation created by unwrappr. 

Example annotation:

---

### [unwrappr](https://opensource.envato.com/projects/unwrappr.html)

**Minor** version upgrade :chart_with_upwards_trend::large_orange_diamond: 0.5.0 → 0.6.0

[_[change-log](https://github.com/envato/unwrappr/blob/HEAD/CHANGELOG.md), [source-code](https://github.com/envato/unwrappr), [gem-diff](https://my.diffend.io/gems/unwrappr/0.5.0/0.6.0)_]





<details>
<summary>Commits</summary>

A change of **15** commits. See the full changes on [the compare page](https://github.com/envato/unwrappr/compare/v0.5.0...v0.6.0).

These are the first 10 commits:
- (def995c) [Update PrSource to support multiple gemfile lock files](https://github.com/envato/unwrappr/commit/def995c1569bbb6d8b5bf86620df14d8e70f06ba)
- (5467750) [Update GitHub client to support annotating multiple gemfile …](https://github.com/envato/unwrappr/commit/546775099f68c58a4eef94ce69efa3dc765f762e)
- (061b2d8) [Pass the configured lock files to the annotator](https://github.com/envato/unwrappr/commit/061b2d88b81a0bd344434ec6402b73fdac9a0a5b)
- (c8a3eb7) [Add the --lock-file arg to the cli](https://github.com/envato/unwrappr/commit/c8a3eb75e05bb72d018857c2cbff3fbf6606ab01)
- (226beb1) [Update changelog for new version](https://github.com/envato/unwrappr/commit/226beb16d4649179f35c2af990994a26ba00a12f)
- (64754c8) [Rubocop fixes](https://github.com/envato/unwrappr/commit/64754c874e4a03c2876819ca3683ce7ac93023f7)
- (7f73229) [Update CHANGELOG.md](https://github.com/envato/unwrappr/commit/7f73229bdfb52db2d93353d96ba2992f8a53b918)
- (c8a6ad5) [Remove unneeded let in spec file](https://github.com/envato/unwrappr/commit/c8a6ad5638b161b8e2b58a46765d7353ddc0b740)
- (dc767ba) [Set default value to an Array](https://github.com/envato/unwrappr/commit/dc767bacb26cabf20cdb2d477d7158e28ac20abc)
- (1a5ed9c) [Provide better usage info for multiple gemfile lock files.](https://github.com/envato/unwrappr/commit/1a5ed9ccf18a2702d8591f0dcd5df8e6da811c0a)


</details>

