### PR TITLE
Handle lockfiles in subdirectories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-[Unreleased]: https://github.com/envato/unwrappr/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/envato/unwrappr/compare/v0.8.0...HEAD
+
+## [0.8.0] 2021-07-22
+
+### Add
+
+- Ability to perform a `bundle update` in subdirectories with the `-R` /
+  `--recursive` flag. ([#90])
+
+[0.8.0]: https://github.com/envato/unwrappr/compare/v0.7.0...v0.8.0
+[#90]: https://github.com/envato/unwrappr/pull/90
 
 ## [0.7.0] 2021-07-15
 

--- a/lib/unwrappr/cli.rb
+++ b/lib/unwrappr/cli.rb
@@ -32,7 +32,7 @@ module Unwrappr
     subcommand 'all', 'run bundle update, push to github, '\
                       'create a pr and annotate changes' do
       def execute
-        Unwrappr.run_unwapper_in_pwd(base_branch: base_branch, lock_files: lock_files)
+        Unwrappr.run_unwrappr_in_pwd(base_branch: base_branch, lock_files: lock_files)
       end
     end
 
@@ -76,13 +76,13 @@ module Unwrappr
             )
           end
 
-          Dir.chdir(repo) { Unwrappr.run_unwapper_in_pwd(base_branch: base_branch, lock_files: lock_files) }
+          Dir.chdir(repo) { Unwrappr.run_unwrappr_in_pwd(base_branch: base_branch, lock_files: lock_files) }
         end
       end
     end
   end
 
-  def self.run_unwapper_in_pwd(base_branch:, lock_files:)
+  def self.run_unwrappr_in_pwd(base_branch:, lock_files:)
     return unless any_lockfile_present?(lock_files)
 
     puts "Doing the unwrappr thing in #{Dir.pwd}"

--- a/lib/unwrappr/cli.rb
+++ b/lib/unwrappr/cli.rb
@@ -29,7 +29,7 @@ module Unwrappr
       exit(0)
     end
 
-    subcommand 'all', 'run bundle update, push to github, '\
+    subcommand 'all', 'run bundle update, push to GitHub, '\
                       'create a pr and annotate changes' do
       option ['-R', '--recursive'],
              :flag,
@@ -48,7 +48,7 @@ module Unwrappr
              required: true
 
       option ['-p', '--pr'], 'PR',
-             'The github PR number',
+             'The GitHub PR number',
              required: true
 
       def execute

--- a/lib/unwrappr/version.rb
+++ b/lib/unwrappr/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Unwrappr
-  VERSION = '0.7.0'
+  VERSION = '0.8.0'
 end


### PR DESCRIPTION
## Context

Some of our projects have separate bundles for deployment under `./deploy`.

## Change

This PR updates the runner to add a _recursive_ flag, which when specified will attempt to perform a `bundle update` in any subdirectory containing a lockfile and annotate this change.
