### PR TITLE
Document how to grab credentials from the keychain

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,15 @@ $ gem install unwrappr
 
 ## Configuration
 
-`unwrappr` needs a [GitHub Personal Access Token](https://github.com/settings/tokens), stored in the environment as `GITHUB_TOKEN`.
+`unwrappr` needs a [GitHub Personal Access
+Token](https://github.com/settings/tokens), stored in the environment as
+`GITHUB_TOKEN`. If you have your Personal Access Token stored in the macOS
+keychain, you can pull this into your shell environment using the `security`
+tool. _E.g:_
+
+```bash
+export GITHUB_TOKEN=$(security find-internet-password -gs github.com 2>&1 | awk -F' ' '$1 == "password:" { print $2 }' | tr -d '"')
+```
 
 To run `unwrappr` in the current working directory use...
 


### PR DESCRIPTION
### Context

I used `unwrappr` locally for the first time in a few months and on a clean machine and had lost my command-line history for grabbing my Personal Access Token.

### Change

Document how I do this, so that others can use it (and so that I don't have to recreate it in future).

### Cc

@orien 