### PR TITLE
CI: add Ruby 3.2 to the RSpec test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['2.5', '2.6', '2.7', '3.0', '3.1']
+        ruby: ['2.5', '2.6', '2.7', '3.0', '3.1', '3.2']
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
         ruby: ['2.5', '2.6', '2.7', '3.0', '3.1', '3.2']
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,7 @@ AllCops:
     - 'spike/*.rb'
     - 'vendor/**/*'
   NewCops: enable
+  SuggestExtensions: false
   TargetRubyVersion: 2.5
 
 Gemspec/RequiredRubyVersion:

--- a/lib/unwrappr/lock_file_diff.rb
+++ b/lib/unwrappr/lock_file_diff.rb
@@ -63,7 +63,7 @@ module Unwrappr
       # '+    websocket-driver (0.6.5)'
       # Careful not to match this (note the wider indent):
       # '+      websocket-extensions (>= 0.1.0)'
-      pattern = /^(?<change_type>[+\-])    (?<gem_name>\S+) \(\d/
+      pattern = /^(?<change_type>[+-])    (?<gem_name>\S+) \(\d/
       match = pattern.match(line)
       return match[:gem_name], match[:change_type] unless match.nil?
     end


### PR DESCRIPTION
Ruby 3.2 has [been released](https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/)! For confidence in compatibility, let's add it to the build matrix.