### PR TITLE
CI: add Ruby 3.4 to the test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3']
+        ruby: ['2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3', '3.4']
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Add
+- Add Ruby 3.4 to the CI test matrix ([#95]).
+
 [Unreleased]: https://github.com/envato/unwrappr/compare/v0.8.1...HEAD
+[#95]: https://github.com/envato/unwrappr/pull/95
 
 ## [0.8.1] 2023-02-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Add
 - Add Ruby 3.4 to the CI test matrix ([#95]).
+- Add `base64` as a runtime dependency to support Ruby 3.4+ ([#95]).
 
 [Unreleased]: https://github.com/envato/unwrappr/compare/v0.8.1...HEAD
 [#95]: https://github.com/envato/unwrappr/pull/95

--- a/unwrappr.gemspec
+++ b/unwrappr.gemspec
@@ -37,6 +37,7 @@ Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength:
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.add_dependency 'base64'
   spec.add_dependency 'bundler', '< 3'
   spec.add_dependency 'bundler-audit', '>= 0.6.0'
   spec.add_dependency 'clamp', '~> 1'


### PR DESCRIPTION
Ruby 3.4 has been released! :tada:
https://www.ruby-lang.org/en/news/2024/12/25/ruby-3-4-0-released/

- Let's add it to the CI build matrix to ensure compatibility.
- Add `base64` as a runtime dependency to support Ruby 3.4+.